### PR TITLE
utility methods for inserting dependencies and other boilerplate

### DIFF
--- a/changelog/@unreleased/pr-22.v2.yml
+++ b/changelog/@unreleased/pr-22.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: utility methods for inserting dependencies and other boilerplate
+  links:
+  - https://github.com/palantir/gradle-plugin-testing/pull/22

--- a/gradle-plugin-testing/src/test/groovy/com/palantir/gradle/plugintesting/TestDependencyVersionsTaskSpec.groovy
+++ b/gradle-plugin-testing/src/test/groovy/com/palantir/gradle/plugintesting/TestDependencyVersionsTaskSpec.groovy
@@ -69,20 +69,14 @@ class TestDependencyVersionsTaskSpec extends AbstractTestingPluginSpec {
 
     def 'write versions with GCV'() {
         given:
+        // remember - the resolved version for this dependency is using the information passed from the version of the plugin
+        // applied to the gradle-plugin-test project itself, _not_ the current version under test.  So the
+        // addBuildScriptDependencies code and the "resolve" logic it calls is the current version, but the information
+        // it is working with is from the last published version of the plugin (assuming that's the one applied to the
+        // root build.gradle file of this project.
+        buildFile << TestContentHelpers.addBuildScriptBlock('mavenCentral()', 'com.palantir.gradle.consistentversions:gradle-consistent-versions')
         //language=gradle
         buildFile << """
-            buildscript {
-                repositories {
-                    mavenCentral()
-                }
-                dependencies {
-                    // remember - this invocation of resolve is using the information passed from the version of the plugin
-                    // applied to this project itself, _not_ the current version under test.  So the resolve code itself is
-                    // the current version, but the information it is working with is from the last published version of
-                    // the plugin.
-                    classpath '${resolve("com.palantir.gradle.consistentversions:gradle-consistent-versions")}'
-                }
-            }
             apply plugin: 'com.palantir.consistent-versions'
             apply plugin: 'groovy'
             apply plugin: 'com.palantir.gradle-plugin-testing'

--- a/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/TestContentHelpers.java
+++ b/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/TestContentHelpers.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -46,6 +47,52 @@ public final class TestContentHelpers {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Add the given repository and dependencies in a new buildscript block.
+     */
+    public static String addBuildScriptBlock(String repository, String... dependencies) {
+        String depBlock = addDependencies("classpath", dependencies);
+        // indent the extra level for being in the buildscript block
+        String result = depBlock.replaceAll("(?m)^", "    ");
+        return """
+                buildscript {
+                    repositories {
+                        %s
+                    }
+                %s
+                }
+                """
+                .formatted(repository, result);
+    }
+
+    /**
+     * Add the given dependencies in a new buildscript block.  Useful to add to a build.gradle file.
+     */
+    public static String addBuildScriptDependencies(String... dependencies) {
+        String depBlock = addDependencies("classpath", dependencies);
+        // indent the extra level for being in the buildscript block
+        String result = depBlock.replaceAll("(?m)^", "    ");
+
+        return "buildscript {\n" + result + "\n}\n";
+    }
+
+    /**
+     * Add the given dependencies in a new dependencies block.
+     */
+    public static String addDependencies(String configuration, String... dependencies) {
+        String depLines = Arrays.stream(dependencies)
+                .map(dep -> "    " + dependency(configuration, dep))
+                .collect(Collectors.joining("\n"));
+        return "dependencies {\n" + depLines + "\n}";
+    }
+
+    /**
+     * Returns a dependency string for the given configuration and dependency.
+     */
+    public static String dependency(String configuration, String dependency) {
+        return configuration + " '" + TestDependencyVersions.resolve(dependency) + "'";
     }
 
     private TestContentHelpers() {}

--- a/plugin-testing-core/src/test/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTests.java
+++ b/plugin-testing-core/src/test/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTests.java
@@ -62,4 +62,39 @@ public class TestDependencyVersionsTests {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("No version found for not:found");
     }
+
+    @Test
+    public void addBuildScriptDependencies() {
+        String buildScript =
+                TestContentHelpers.addBuildScriptDependencies("foo:bar", "com.palantir:gradle-plugin-testing");
+        assertThat(buildScript)
+                .isEqualTo(
+                        """
+                buildscript {
+                    dependencies {
+                        classpath 'foo:bar:100'
+                        classpath 'com.palantir:gradle-plugin-testing:1.2.3'
+                    }
+                }
+                """);
+    }
+
+    @Test
+    public void addBuildScriptBlock() {
+        String buildScript = TestContentHelpers.addBuildScriptBlock(
+                "mavenCentral()", "foo:bar", "com.palantir:gradle-plugin-testing");
+        assertThat(buildScript)
+                .isEqualTo(
+                        """
+                buildscript {
+                    repositories {
+                        mavenCentral()
+                    }
+                    dependencies {
+                        classpath 'foo:bar:100'
+                        classpath 'com.palantir:gradle-plugin-testing:1.2.3'
+                    }
+                }
+                """);
+    }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Still playing around with how much flexibility/automation we want.  Like I could see the "repositories" bit of the call being set using the extension so that it's passed in automatically rather than as a call parameter.  Then any company that has their own artifactory or such could override the default values of the extension with an "internal" plugin that wraps this one.

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

