### PR TITLE
GradleTestVersions should always include `GradleVersion.current()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ dependencies {
 # Resolution of Gradle versions to test against
 Similarly, tests may hardcode versions of Gradle that they need to stay compatible with. These versions also get stale and PRs start failing for the inverse reason of the above - the code in the plugin or a dependency of it is updated and is no longer compatible with an old version of Gradle. For example, attempting to update jackson libraries from `2.15.0` -> `2.17.0` would fail if a test tried to run on Gradle versiosn < `7.6.4` (when compatibility with jackson `2.17.0` was fixed).
 
-The `GradleTestVersions` class can provide up-to-date versions of Gradle to test against.  
+The `GradleTestVersions` class can provide up-to-date versions of Gradle to test against. It will always include the current Gradle version.
 ```groovy
 import nebula.test.IntegrationSpec
 import com.palantir.gradle.plugintesting.GradleTestVersions

--- a/changelog/@unreleased/pr-99.v2.yml
+++ b/changelog/@unreleased/pr-99.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: GradleTestVersions should always include `GradleVersion.current()`
+  links:
+  - https://github.com/palantir/gradle-plugin-testing/pull/99

--- a/gradle-plugin-testing/build.gradle
+++ b/gradle-plugin-testing/build.gradle
@@ -7,7 +7,8 @@ apply plugin: 'com.palantir.external-publish-gradle-plugin'
 dependencies {
     implementation project(':plugin-testing-core')
     implementation 'com.palantir.baseline:gradle-baseline-java'
-
+    implementation 'com.google.guava:guava'
+    
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'com.netflix.nebula:nebula-test'
 

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.plugintesting;
 
+import com.google.common.collect.ImmutableSet;
 import com.palantir.baseline.tasks.CheckUnusedDependenciesParentTask;
 import java.util.Optional;
 import java.util.Set;
@@ -29,7 +30,6 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.internal.impldep.com.google.common.collect.ImmutableSet;
 import org.gradle.util.GradleVersion;
 
 public class PluginTestingPlugin implements Plugin<Project> {

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.plugintesting;
 
 import com.palantir.baseline.tasks.CheckUnusedDependenciesParentTask;
 import java.util.Optional;
+import java.util.Set;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
@@ -28,6 +29,8 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.impldep.com.google.common.collect.ImmutableSet;
+import org.gradle.util.GradleVersion;
 
 public class PluginTestingPlugin implements Plugin<Project> {
     /**
@@ -85,8 +88,11 @@ public class PluginTestingPlugin implements Plugin<Project> {
                                     .getAbsolutePath());
 
                     // add system property for what versions of gradle should be used in tests
-                    String versions =
-                            String.join(",", testUtilsExt.getGradleVersions().get());
+                    Set<String> gradleVersions = ImmutableSet.<String>builder()
+                            .addAll(testUtilsExt.getGradleVersions().get())
+                            .add(GradleVersion.current().getVersion())
+                            .build();
+                    String versions = String.join(",", gradleVersions);
                     test.systemProperty(GradleTestVersions.TEST_GRADLE_VERSIONS_SYSTEM_PROPERTY, versions);
 
                     // add system property to ignore gradle deprecations so that nebula tests don't fail


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
GradleTestVersions always includes `GradleVersion.current()`. This will make sure that when gradle-wrapper upgrades, we will test the gradle plugin against the current Gradle Version.

==COMMIT_MSG==
GradleTestVersions should always include `GradleVersion.current()`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

