### PR TITLE
Don't test Gradle 7 by default

### DIFF
--- a/changelog/@unreleased/pr-124.v2.yml
+++ b/changelog/@unreleased/pr-124.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '`GradleTestVersions` no longer includes Gradle 7 by default.'
+  links:
+  - https://github.com/palantir/gradle-plugin-testing/pull/124

--- a/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/GradleTestVersions.java
+++ b/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/GradleTestVersions.java
@@ -30,7 +30,7 @@ import java.util.function.Supplier;
  */
 public final class GradleTestVersions {
     static final String TEST_GRADLE_VERSIONS_SYSTEM_PROPERTY = "TEST_GRADLE_VERSIONS";
-    static final List<String> DEFAULT_TEST_GRADLE_VERSIONS = Arrays.asList("7.6.4", "8.8");
+    static final List<String> DEFAULT_TEST_GRADLE_VERSIONS = Arrays.asList("8.14.3");
 
     private static final Supplier<List<String>> gradleVersionsSupplier =
             Suppliers.memoize(GradleTestVersions::loadVersions);


### PR DESCRIPTION
Gradle 7 [cannot be used](https://docs.gradle.org/current/userguide/compatibility.html) with tests that are run using Java 21. We are rolling out `runtime = 21` everywhere, so we need to stop testing against Gradle 7.