### PR TITLE
Make `gradle-plugin-testing` compatible with the Configuration Cache

### DIFF
--- a/changelog/@unreleased/pr-152.v2.yml
+++ b/changelog/@unreleased/pr-152.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make `gradle-plugin-testing` compatible with the Configuration-Cache
+  links:
+  - https://github.com/palantir/gradle-plugin-testing/pull/152

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -98,27 +98,32 @@ public class PluginTestingPlugin implements Plugin<Project> {
         project.getTasks().withType(Test.class).configureEach(test -> {
             test.dependsOn(testDependencyVersions);
 
-            // need to use the doFirst so that any custom settings on the extension are applied before reading
-            // the values and setting the system properties.
-            Action<Task> action = _task -> {
-                // add system property for name of file to read for dependency versions
-                test.systemProperty(
-                        TestDependencyVersions.TEST_DEPENDENCIES_FILE_SYSTEM_PROPERTY,
-                        testDependenciesFileAbsolutePath.get());
+            // doFirst so any custom settings on the extension are applied before reading the values and setting
+            // the system properties.
 
-                // add system property for what versions of gradle should be used in tests
-                String versions =
-                        String.join(",", testUtilsExt.getGradleVersions().get());
-                test.systemProperty(GradleTestVersions.TEST_GRADLE_VERSIONS_SYSTEM_PROPERTY, versions);
+            // Do not replace with a lambda! Lambdas aren't build cacheable.
+            // https://github.com/gradle/gradle/issues/5510
+            test.doFirst(new Action<>() {
+                @Override
+                public void execute(Task _task) {
+                    // add system property for name of file to read for dependency versions
+                    test.systemProperty(
+                            TestDependencyVersions.TEST_DEPENDENCIES_FILE_SYSTEM_PROPERTY,
+                            testDependenciesFileAbsolutePath.get());
 
-                // add system property to ignore gradle deprecations so that nebula tests don't fail
-                if (testUtilsExt.getIgnoreGradleDeprecations().get()) {
-                    // from
-                    // https://github.com/nebula-plugins/nebula-test/blob/main/src/main/groovy/nebula/test/IntegrationBase.groovy
-                    test.systemProperty("ignoreDeprecations", "true");
+                    // add system property for what versions of gradle should be used in tests
+                    String versions =
+                            String.join(",", testUtilsExt.getGradleVersions().get());
+                    test.systemProperty(GradleTestVersions.TEST_GRADLE_VERSIONS_SYSTEM_PROPERTY, versions);
+
+                    // add system property to ignore gradle deprecations so that nebula tests don't fail
+                    if (testUtilsExt.getIgnoreGradleDeprecations().get()) {
+                        // from
+                        // https://github.com/nebula-plugins/nebula-test/blob/main/src/main/groovy/nebula/test/IntegrationBase.groovy
+                        test.systemProperty("ignoreDeprecations", "true");
+                    }
                 }
-            };
-            test.doFirst(action);
+            });
         });
     }
 

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -16,6 +16,7 @@
 package com.palantir.gradle.plugintesting;
 
 import com.palantir.baseline.tasks.CheckUnusedDependenciesParentTask;
+import com.palantir.gradle.plugintesting.TestDependencyVersionsTask.TestDependency;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -25,8 +26,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -71,9 +70,10 @@ public class PluginTestingPlugin implements Plugin<Project> {
                     SourceSet sourceSet = sourceSetContainer.getByName(SourceSet.TEST_SOURCE_SET_NAME);
                     NamedDomainObjectProvider<Configuration> testRuntimeConfig =
                             project.getConfigurations().named(sourceSet.getRuntimeClasspathConfigurationName());
-                    Provider<Iterable<ModuleVersionIdentifier>> testRuntimeDependencies = testRuntimeConfig.map(
-                            config -> config.getIncoming().getResolutionResult().getAllComponents().stream()
-                                    .map(ResolvedComponentResult::getModuleVersion)
+                    Provider<Iterable<TestDependency>> testRuntimeDependencies = testRuntimeConfig.map(
+                            config -> config.getResolvedConfiguration().getFirstLevelModuleDependencies().stream()
+                                    .map(dep -> new TestDependency(
+                                            dep.getModuleGroup(), dep.getModuleName(), dep.getModuleVersion()))
                                     .collect(Collectors.toUnmodifiableSet()));
                     task.getTestRuntimeDependencies().set(testRuntimeDependencies);
                 });

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -17,7 +17,6 @@ package com.palantir.gradle.plugintesting;
 
 import com.palantir.baseline.tasks.CheckUnusedDependenciesParentTask;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.gradle.api.Action;
@@ -27,8 +26,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
@@ -48,8 +46,6 @@ public class PluginTestingPlugin implements Plugin<Project> {
     private static String coreMavenCoordinates(String name) {
         return MAVEN_GROUP + ":" + name;
     }
-
-    private static final Logger log = Logging.getLogger(PluginTestingPlugin.class);
 
     /**
      * Applies the plugin to the given project.
@@ -77,17 +73,7 @@ public class PluginTestingPlugin implements Plugin<Project> {
                             project.getConfigurations().named(sourceSet.getRuntimeClasspathConfigurationName());
                     Provider<Iterable<ModuleVersionIdentifier>> testRuntimeDependencies = testRuntimeConfig.map(
                             config -> config.getIncoming().getResolutionResult().getAllComponents().stream()
-                                    .map(component -> {
-                                        ModuleVersionIdentifier moduleInfo = component.getModuleVersion();
-                                        if (moduleInfo == null) {
-                                            log.info(
-                                                    "Component with null module version will not be included in {}: {}",
-                                                    TestDependencyVersionsTask.FILENAME,
-                                                    component.getId());
-                                        }
-                                        return moduleInfo;
-                                    })
-                                    .filter(Objects::nonNull)
+                                    .map(ResolvedComponentResult::getModuleVersion)
                                     .collect(Collectors.toUnmodifiableSet()));
                     task.getTestRuntimeDependencies().set(testRuntimeDependencies);
                 });

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -17,13 +17,19 @@ package com.palantir.gradle.plugintesting;
 
 import com.palantir.baseline.tasks.CheckUnusedDependenciesParentTask;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
@@ -42,6 +48,8 @@ public class PluginTestingPlugin implements Plugin<Project> {
     private static String coreMavenCoordinates(String name) {
         return MAVEN_GROUP + ":" + name;
     }
+
+    private static final Logger log = Logging.getLogger(PluginTestingPlugin.class);
 
     /**
      * Applies the plugin to the given project.
@@ -67,38 +75,47 @@ public class PluginTestingPlugin implements Plugin<Project> {
                     SourceSet sourceSet = sourceSetContainer.getByName(SourceSet.TEST_SOURCE_SET_NAME);
                     NamedDomainObjectProvider<Configuration> testRuntimeConfig =
                             project.getConfigurations().named(sourceSet.getRuntimeClasspathConfigurationName());
-                    task.getClasspathConfiguration().set(testRuntimeConfig);
+                    Provider<Iterable<ModuleVersionIdentifier>> testRuntimeDependencies = testRuntimeConfig.map(
+                            config -> config.getIncoming().getResolutionResult().getAllComponents().stream()
+                                    .map(component -> {
+                                        ModuleVersionIdentifier moduleInfo = component.getModuleVersion();
+                                        if (moduleInfo == null) {
+                                            log.info(
+                                                    "Component with null module version will not be included in {}: {}",
+                                                    TestDependencyVersionsTask.FILENAME,
+                                                    component.getId());
+                                        }
+                                        return moduleInfo;
+                                    })
+                                    .filter(Objects::nonNull)
+                                    .collect(Collectors.toUnmodifiableSet()));
+                    task.getTestRuntimeDependencies().set(testRuntimeDependencies);
                 });
+
+        Provider<String> testDependenciesFileAbsolutePath = project.provider(() ->
+                testDependencyVersions.get().getOutputFile().get().getAsFile().getAbsolutePath());
 
         project.getTasks().withType(Test.class).configureEach(test -> {
             test.dependsOn(testDependencyVersions);
 
             // need to use the doFirst so that any custom settings on the extension are applied before reading
             // the values and setting the system properties.
-            Action<Task> action = new Action<>() {
-                @Override
-                public void execute(Task _task) {
-                    // add system property for name of file to read for dependency versions
-                    test.systemProperty(
-                            TestDependencyVersions.TEST_DEPENDENCIES_FILE_SYSTEM_PROPERTY,
-                            testDependencyVersions
-                                    .get()
-                                    .getOutputFile()
-                                    .get()
-                                    .getAsFile()
-                                    .getAbsolutePath());
+            Action<Task> action = _task -> {
+                // add system property for name of file to read for dependency versions
+                test.systemProperty(
+                        TestDependencyVersions.TEST_DEPENDENCIES_FILE_SYSTEM_PROPERTY,
+                        testDependenciesFileAbsolutePath.get());
 
-                    // add system property for what versions of gradle should be used in tests
-                    String versions =
-                            String.join(",", testUtilsExt.getGradleVersions().get());
-                    test.systemProperty(GradleTestVersions.TEST_GRADLE_VERSIONS_SYSTEM_PROPERTY, versions);
+                // add system property for what versions of gradle should be used in tests
+                String versions =
+                        String.join(",", testUtilsExt.getGradleVersions().get());
+                test.systemProperty(GradleTestVersions.TEST_GRADLE_VERSIONS_SYSTEM_PROPERTY, versions);
 
-                    // add system property to ignore gradle deprecations so that nebula tests don't fail
-                    if (testUtilsExt.getIgnoreGradleDeprecations().get()) {
-                        // from
-                        // https://github.com/nebula-plugins/nebula-test/blob/main/src/main/groovy/nebula/test/IntegrationBase.groovy
-                        test.systemProperty("ignoreDeprecations", "true");
-                    }
+                // add system property to ignore gradle deprecations so that nebula tests don't fail
+                if (testUtilsExt.getIgnoreGradleDeprecations().get()) {
+                    // from
+                    // https://github.com/nebula-plugins/nebula-test/blob/main/src/main/groovy/nebula/test/IntegrationBase.groovy
+                    test.systemProperty("ignoreDeprecations", "true");
                 }
             };
             test.doFirst(action);

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTask.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTask.java
@@ -23,8 +23,10 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.CacheableTask;
@@ -36,8 +38,11 @@ import org.gradle.api.tasks.TaskAction;
 public abstract class TestDependencyVersionsTask extends DefaultTask {
     public static final String FILENAME = "plugin-testing/dependency-versions.properties";
 
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
+
     public TestDependencyVersionsTask() {
-        getOutputFile().convention(getProject().getLayout().getBuildDirectory().file(FILENAME));
+        getOutputFile().convention(getProjectLayout().getBuildDirectory().file(FILENAME));
     }
 
     @Input

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTask.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTask.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.plugintesting;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -25,7 +26,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.SetProperty;
@@ -36,6 +36,8 @@ import org.gradle.api.tasks.TaskAction;
 
 @CacheableTask
 public abstract class TestDependencyVersionsTask extends DefaultTask {
+    public record TestDependency(String group, String name, String version) implements Serializable {}
+
     public static final String FILENAME = "plugin-testing/dependency-versions.properties";
 
     @Inject
@@ -46,7 +48,7 @@ public abstract class TestDependencyVersionsTask extends DefaultTask {
     }
 
     @Input
-    abstract SetProperty<ModuleVersionIdentifier> getTestRuntimeDependencies();
+    abstract SetProperty<TestDependency> getTestRuntimeDependencies();
 
     @OutputFile
     public abstract RegularFileProperty getOutputFile();
@@ -65,9 +67,9 @@ public abstract class TestDependencyVersionsTask extends DefaultTask {
     /**
      * Returns a list of all dependencies, sorted and deduplicated.
      */
-    private static List<String> getDependencyStrings(Set<ModuleVersionIdentifier> dependencies) {
+    private static List<String> getDependencyStrings(Set<TestDependency> dependencies) {
         return dependencies.stream()
-                .map(dep -> dep.getGroup() + ":" + dep.getName() + "=" + dep.getVersion())
+                .map(dep -> dep.group() + ":" + dep.name() + "=" + dep.version())
                 .sorted()
                 .distinct()
                 .collect(Collectors.toList());

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTask.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTask.java
@@ -21,37 +21,35 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.tasks.CacheableTask;
-import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
 @CacheableTask
 public abstract class TestDependencyVersionsTask extends DefaultTask {
+    public static final String FILENAME = "plugin-testing/dependency-versions.properties";
 
     public TestDependencyVersionsTask() {
-        getOutputFile()
-                .convention(getProject()
-                        .getLayout()
-                        .getBuildDirectory()
-                        .file("plugin-testing/dependency-versions.properties"));
+        getOutputFile().convention(getProject().getLayout().getBuildDirectory().file(FILENAME));
     }
 
-    @Classpath
-    abstract Property<Configuration> getClasspathConfiguration();
+    @Input
+    abstract SetProperty<ModuleVersionIdentifier> getTestRuntimeDependencies();
 
     @OutputFile
     public abstract RegularFileProperty getOutputFile();
 
     @TaskAction
     public final void doAction() {
-        List<String> depSet = getDependencyStrings(getClasspathConfiguration().get());
-        String depsString = String.join("\n", depSet);
+        String depsString = String.join(
+                "\n", getDependencyStrings(getTestRuntimeDependencies().get()));
         try {
             Files.write(getOutputFile().get().getAsFile().toPath(), depsString.getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
@@ -62,9 +60,9 @@ public abstract class TestDependencyVersionsTask extends DefaultTask {
     /**
      * Returns a list of all dependencies, sorted and deduplicated.
      */
-    private static List<String> getDependencyStrings(Configuration config) {
-        return config.getResolvedConfiguration().getFirstLevelModuleDependencies().stream()
-                .map(dep -> dep.getModuleGroup() + ":" + dep.getModuleName() + "=" + dep.getModuleVersion())
+    private static List<String> getDependencyStrings(Set<ModuleVersionIdentifier> dependencies) {
+        return dependencies.stream()
+                .map(dep -> dep.getGroup() + ":" + dep.getName() + "=" + dep.getVersion())
                 .sorted()
                 .distinct()
                 .collect(Collectors.toList());

--- a/gradle-plugin-testing/src/test/groovy/com/palantir/gradle/plugintesting/ConfigurationCacheTest.groovy
+++ b/gradle-plugin-testing/src/test/groovy/com/palantir/gradle/plugintesting/ConfigurationCacheTest.groovy
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.plugintesting
+
+
+
+class ConfigurationCacheTest extends ConfigurationCacheSpec {
+
+    def "test task runs with configuration cache"() {
+        given:
+        // language=Gradle
+        buildFile << """
+            apply plugin: 'com.palantir.gradle-plugin-testing'
+            apply plugin: 'java-library'
+            
+            repositories {
+                mavenCentral()
+                mavenLocal()
+            }
+        """.stripIndent(true)
+
+        expect:
+        def projectVersion = Optional.ofNullable(System.getProperty('projectVersion')).orElseThrow()
+        def systemProp = "-P${PluginTestingPlugin.PLUGIN_VERSION_PROPERTY_NAME}=${projectVersion}".toString()
+        runTasksWithConfigurationCache("classes", systemProp)
+    }
+}

--- a/gradle-plugin-testing/src/test/groovy/com/palantir/gradle/plugintesting/ConfigurationCacheTest.groovy
+++ b/gradle-plugin-testing/src/test/groovy/com/palantir/gradle/plugintesting/ConfigurationCacheTest.groovy
@@ -36,6 +36,6 @@ class ConfigurationCacheTest extends ConfigurationCacheSpec {
         expect:
         def projectVersion = Optional.ofNullable(System.getProperty('projectVersion')).orElseThrow()
         def systemProp = "-P${PluginTestingPlugin.PLUGIN_VERSION_PROPERTY_NAME}=${projectVersion}".toString()
-        runTasksWithConfigurationCache("classes", systemProp)
+        runTasksWithConfigurationCache("test", systemProp)
     }
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We are rolling out the Configuration Cache (CC). To start, we are trying to get `gw classes` and `gw test` to work with the configuration cache. To achieve that, `PluginTestingPlugin` has to be made CC compatible by solving the following CC violations:

- `Test` was capturing `TestDependencyVersionsTask` as an input
- `TestDependencyVersionsTask` was taking in `Configuration` as an input

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Wire up `Test` and `TestDependencyVersionsTask` with providers, and narrow the input type of `TestDependencyVersionsTask`.

==COMMIT_MSG==
Make `gradle-plugin-testing` compatible with the Configuration-Cache
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

