### PR TITLE
Transitively bring in nebula-test for consumers by making it a `api` dependency

### DIFF
--- a/configuration-cache-spec/build.gradle
+++ b/configuration-cache-spec/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'groovy'
 apply plugin: 'com.palantir.external-publish-jar'
 
 dependencies {
-    implementation 'com.netflix.nebula:nebula-test'
+    api 'com.netflix.nebula:nebula-test'
     implementation 'org.codehaus.groovy:groovy'
     implementation 'org.spockframework:spock-core'
     implementation gradleTestKit()


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Consumers of configuration-cache-spec have to bring in nebula-test explicitly for their ConfigurationCacheSpecs to be recognized as tests. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Transitively bring in nebula-test for consumers by making it a `api` dependency
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

