### PR TITLE
Add custom AssertJ assertions, string formatting, and Directory API

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/GradleAssertions.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/GradleAssertions.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.assertions;
+
+import com.palantir.gradle.testing.execution.InvocationResult;
+
+/**
+ * Entry point for custom AssertJ assertions for Gradle plugin testing.
+ * <p>
+ * Usage:
+ * <pre>
+ * import static com.palantir.gradle.testing.assertions.GradleAssertions.assertThat;
+ *
+ * assertThat(invocationResult)
+ *     .task(":myTask")
+ *     .hasOutcome()
+ *     .isNotIn(TaskOutcome.UP_TO_DATE, TaskOutcome.FROM_CACHE);
+ * </pre>
+ */
+public final class GradleAssertions {
+
+    private GradleAssertions() {}
+
+    public static InvocationResultAssert assertThat(InvocationResult invocationResult) {
+        return new InvocationResultAssert(invocationResult);
+    }
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/InvocationResultAssert.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/InvocationResultAssert.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.assertions;
+
+import com.palantir.gradle.testing.execution.InvocationResult;
+import com.palantir.gradle.testing.execution.TaskResult;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.OptionalAssert;
+
+public final class InvocationResultAssert extends AbstractObjectAssert<InvocationResultAssert, InvocationResult> {
+
+    InvocationResultAssert(InvocationResult invocationResult) {
+        super(invocationResult, InvocationResultAssert.class);
+    }
+
+    public TaskResultOptionalAssert task(String taskPath) {
+        isNotNull();
+        return new TaskResultOptionalAssert(actual.task(taskPath));
+    }
+
+    public InvocationResultAssert hasOutput(String expectedOutput) {
+        isNotNull();
+        if (!actual.output().contains(expectedOutput)) {
+            failWithMessage("Expected output to contain <%s> but was <%s>", expectedOutput, actual.output());
+        }
+        return this;
+    }
+
+    public static final class TaskResultOptionalAssert extends OptionalAssert<TaskResult> {
+
+        TaskResultOptionalAssert(java.util.Optional<TaskResult> optional) {
+            super(optional);
+        }
+
+        @Override
+        public TaskResultOptionalAssert as(String description, Object... args) {
+            return (TaskResultOptionalAssert) super.as(description, args);
+        }
+
+        public TaskOutcomeAssert hasOutcome() {
+            isPresent();
+            return new TaskOutcomeAssert(actual.get().outcome());
+        }
+
+        public TaskResultOptionalAssert hasPath(String expectedPath) {
+            isPresent();
+            TaskResult taskResult = actual.get();
+            if (!taskResult.path().equals(expectedPath)) {
+                failWithMessage("Expected task path to be <%s> but was <%s>", expectedPath, taskResult.path());
+            }
+            return this;
+        }
+    }
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/TaskOutcomeAssert.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/TaskOutcomeAssert.java
@@ -30,10 +30,7 @@ public final class TaskOutcomeAssert extends AbstractObjectAssert<TaskOutcomeAss
     public TaskOutcomeAssert isIn(TaskOutcome... expectedOutcomes) {
         isNotNull();
         if (!contains(expectedOutcomes)) {
-            failWithMessage(
-                    "Expected task outcome to be in %s but was <%s>",
-                    formatOutcomes(expectedOutcomes),
-                    actual);
+            failWithMessage("Expected task outcome to be in %s but was <%s>", formatOutcomes(expectedOutcomes), actual);
         }
         return this;
     }
@@ -42,9 +39,7 @@ public final class TaskOutcomeAssert extends AbstractObjectAssert<TaskOutcomeAss
         isNotNull();
         if (contains(excludedOutcomes)) {
             failWithMessage(
-                    "Expected task outcome not to be in %s but was <%s>",
-                    formatOutcomes(excludedOutcomes),
-                    actual);
+                    "Expected task outcome not to be in %s but was <%s>", formatOutcomes(excludedOutcomes), actual);
         }
         return this;
     }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/TaskOutcomeAssert.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/TaskOutcomeAssert.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.assertions;
+
+import com.palantir.gradle.testing.execution.TaskOutcome;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractObjectAssert;
+
+public final class TaskOutcomeAssert extends AbstractObjectAssert<TaskOutcomeAssert, TaskOutcome> {
+
+    TaskOutcomeAssert(TaskOutcome taskOutcome) {
+        super(taskOutcome, TaskOutcomeAssert.class);
+    }
+
+    public TaskOutcomeAssert isIn(TaskOutcome... expectedOutcomes) {
+        isNotNull();
+        if (!contains(expectedOutcomes)) {
+            failWithMessage(
+                    "Expected task outcome to be in %s but was <%s>",
+                    formatOutcomes(expectedOutcomes),
+                    actual);
+        }
+        return this;
+    }
+
+    public TaskOutcomeAssert isNotIn(TaskOutcome... excludedOutcomes) {
+        isNotNull();
+        if (contains(excludedOutcomes)) {
+            failWithMessage(
+                    "Expected task outcome not to be in %s but was <%s>",
+                    formatOutcomes(excludedOutcomes),
+                    actual);
+        }
+        return this;
+    }
+
+    private boolean contains(TaskOutcome[] outcomes) {
+        return Arrays.stream(outcomes).anyMatch(outcome -> outcome == actual);
+    }
+
+    private static String formatOutcomes(TaskOutcome[] outcomes) {
+        return Arrays.stream(outcomes).map(Enum::name).collect(Collectors.joining(", ", "[", "]"));
+    }
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/TaskResultAssert.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertions/TaskResultAssert.java
@@ -1,0 +1,40 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.assertions;
+
+import com.palantir.gradle.testing.execution.TaskResult;
+import org.assertj.core.api.AbstractObjectAssert;
+
+public final class TaskResultAssert extends AbstractObjectAssert<TaskResultAssert, TaskResult> {
+
+    TaskResultAssert(TaskResult taskResult) {
+        super(taskResult, TaskResultAssert.class);
+    }
+
+    public TaskOutcomeAssert hasOutcome() {
+        isNotNull();
+        return new TaskOutcomeAssert(actual.outcome());
+    }
+
+    public TaskResultAssert hasPath(String expectedPath) {
+        isNotNull();
+        if (!actual.path().equals(expectedPath)) {
+            failWithMessage("Expected task path to be <%s> but was <%s>", expectedPath, actual.path());
+        }
+        return this;
+    }
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/Directory.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/Directory.java
@@ -1,0 +1,41 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.files;
+
+import com.google.errorprone.annotations.RestrictedApi;
+import com.palantir.gradle.testing.RestrictedCreation;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.assertj.core.api.AbstractPathAssert;
+import org.assertj.core.api.Assertions;
+
+public record Directory(Path path) implements FileFactory {
+    @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
+    public Directory {
+        try {
+            Files.createDirectories(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public AbstractPathAssert<?> assertThat() {
+        return Assertions.assertThat(path);
+    }
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/FileFactory.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/FileFactory.java
@@ -30,6 +30,10 @@ public interface FileFactory {
         return new ArbitraryFile(resolvePath(path));
     }
 
+    default Directory directory(String path) {
+        return new Directory(resolvePath(path));
+    }
+
     default GradleFile gradleFile(String path) {
         return new RegularGradleFile(resolvePath(path));
     }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/ProjectFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/ProjectFile.java
@@ -34,33 +34,43 @@ public interface ProjectFile<T extends ProjectFile<T>> {
 
     @FormatMethod
     default T overwrite(@FormatString String text, Object... args) {
-        writeString(path(), args.length > 0 ? text.formatted(args) : text, StandardOpenOption.TRUNCATE_EXISTING);
+        writeString(path(), format(text, args), StandardOpenOption.TRUNCATE_EXISTING);
+        return (T) this;
+    }
+
+    default T append(String text) {
+        writeString(path(), text, StandardOpenOption.APPEND);
         return (T) this;
     }
 
     @FormatMethod
     default T append(@FormatString String text, Object... args) {
-        writeString(path(), args.length > 0 ? text.formatted(args) : text, StandardOpenOption.APPEND);
-        return (T) this;
+        return append(format(text, args));
     }
 
-    default T appendLine(String line, Object... args) {
-        String formattedLine = args.length > 0 ? line.formatted(args) : line;
-        writeString(path(), formattedLine + "\n", StandardOpenOption.APPEND);
+    @FormatMethod
+    default T appendLine(@FormatString String line, Object... args) {
+        return append(format(line, args) + "\n");
+    }
+
+    default T prepend(String text) {
+        edit(existingText -> text + existingText);
         return (T) this;
     }
 
     @FormatMethod
     default T prepend(@FormatString String text, Object... args) {
-        String formattedText = args.length > 0 ? text.formatted(args) : text;
-        edit(existingText -> formattedText + existingText);
-        return (T) this;
+        return prepend(format(text, args));
     }
 
-    default T prependLine(String line, Object... args) {
-        String formattedLine = args.length > 0 ? line.formatted(args) : line;
-        edit(existingText -> formattedLine + "\n" + existingText);
-        return (T) this;
+    @FormatMethod
+    default T prependLine(@FormatString String line, Object... args) {
+        return prepend(format(line, args) + "\n");
+    }
+
+    @FormatMethod
+    private static String format(String text, Object... args) {
+        return args.length > 0 ? text.formatted(args) : text;
     }
 
     interface FileEditor {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/ProjectFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/ProjectFile.java
@@ -32,14 +32,14 @@ import org.assertj.core.api.Assertions;
 public interface ProjectFile<T extends ProjectFile<T>> {
     Path path();
 
-    @FormatMethod
-    default T overwrite(@FormatString String text, Object... args) {
-        return overwrite(args.length > 0 ? text.formatted(args) : text);
-    }
-
     default T overwrite(String text) {
         writeString(path(), text, StandardOpenOption.TRUNCATE_EXISTING);
         return (T) this;
+    }
+
+    @FormatMethod
+    default T overwrite(@FormatString String text, Object... args) {
+        return overwrite(args.length > 0 ? text.formatted(args) : text);
     }
 
     default T append(String text) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/ProjectFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/ProjectFile.java
@@ -16,6 +16,8 @@
 
 package com.palantir.gradle.testing.files;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -30,27 +32,35 @@ import org.assertj.core.api.Assertions;
 public interface ProjectFile<T extends ProjectFile<T>> {
     Path path();
 
-    default T overwrite(String text) {
-        writeString(path(), text, StandardOpenOption.TRUNCATE_EXISTING);
+    @FormatMethod
+    default T overwrite(@FormatString String text, Object... args) {
+        writeString(path(), args.length > 0 ? text.formatted(args) : text, StandardOpenOption.TRUNCATE_EXISTING);
         return (T) this;
     }
 
-    default T append(String text) {
-        writeString(path(), text, StandardOpenOption.APPEND);
+    @FormatMethod
+    default T append(@FormatString String text, Object... args) {
+        writeString(path(), args.length > 0 ? text.formatted(args) : text, StandardOpenOption.APPEND);
         return (T) this;
     }
 
-    default T appendLine(String line) {
-        return append(line + "\n");
-    }
-
-    default T prepend(String text) {
-        edit(existingText -> text + existingText);
+    default T appendLine(String line, Object... args) {
+        String formattedLine = args.length > 0 ? line.formatted(args) : line;
+        writeString(path(), formattedLine + "\n", StandardOpenOption.APPEND);
         return (T) this;
     }
 
-    default T prependLine(String line) {
-        return prepend(line + "\n");
+    @FormatMethod
+    default T prepend(@FormatString String text, Object... args) {
+        String formattedText = args.length > 0 ? text.formatted(args) : text;
+        edit(existingText -> formattedText + existingText);
+        return (T) this;
+    }
+
+    default T prependLine(String line, Object... args) {
+        String formattedLine = args.length > 0 ? line.formatted(args) : line;
+        edit(existingText -> formattedLine + "\n" + existingText);
+        return (T) this;
     }
 
     interface FileEditor {
@@ -59,8 +69,9 @@ public interface ProjectFile<T extends ProjectFile<T>> {
 
     default T edit(FileEditor editor) {
         String text = Files.exists(path()) ? text() : "";
-
-        return overwrite(editor.edit(text));
+        String editedText = editor.edit(text);
+        writeString(path(), editedText, StandardOpenOption.TRUNCATE_EXISTING);
+        return (T) this;
     }
 
     default T createEmpty() {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/ProjectFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/ProjectFile.java
@@ -34,7 +34,11 @@ public interface ProjectFile<T extends ProjectFile<T>> {
 
     @FormatMethod
     default T overwrite(@FormatString String text, Object... args) {
-        writeString(path(), format(text, args), StandardOpenOption.TRUNCATE_EXISTING);
+        return overwrite(args.length > 0 ? text.formatted(args) : text);
+    }
+
+    default T overwrite(String text) {
+        writeString(path(), text, StandardOpenOption.TRUNCATE_EXISTING);
         return (T) this;
     }
 
@@ -48,9 +52,13 @@ public interface ProjectFile<T extends ProjectFile<T>> {
         return append(format(text, args));
     }
 
+    default T appendLine(String line) {
+        return append(line + "\n");
+    }
+
     @FormatMethod
     default T appendLine(@FormatString String line, Object... args) {
-        return append(format(line, args) + "\n");
+        return appendLine(format(line, args));
     }
 
     default T prepend(String text) {
@@ -63,9 +71,13 @@ public interface ProjectFile<T extends ProjectFile<T>> {
         return prepend(format(text, args));
     }
 
+    default T prependLine(String line) {
+        return prepend(line + "\n");
+    }
+
     @FormatMethod
     default T prependLine(@FormatString String line, Object... args) {
-        return prepend(format(line, args) + "\n");
+        return prependLine(format(line, args));
     }
 
     @FormatMethod
@@ -79,9 +91,7 @@ public interface ProjectFile<T extends ProjectFile<T>> {
 
     default T edit(FileEditor editor) {
         String text = Files.exists(path()) ? text() : "";
-        String editedText = editor.edit(text);
-        writeString(path(), editedText, StandardOpenOption.TRUNCATE_EXISTING);
-        return (T) this;
+        return overwrite(editor.edit(text));
     }
 
     default T createEmpty() {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
@@ -35,7 +35,8 @@ public interface GradleFile extends ProjectFile<GradleFile> {
     }
 
     @Override
-    default GradleFile appendLine(@Language("Gradle") String line, Object... args) {
+    @FormatMethod
+    default GradleFile appendLine(@Language("Gradle") @FormatString String line, Object... args) {
         return ProjectFile.super.appendLine(line, args);
     }
 
@@ -46,7 +47,8 @@ public interface GradleFile extends ProjectFile<GradleFile> {
     }
 
     @Override
-    default GradleFile prependLine(@Language("Gradle") String line, Object... args) {
+    @FormatMethod
+    default GradleFile prependLine(@Language("Gradle") @FormatString String line, Object... args) {
         return ProjectFile.super.prependLine(line, args);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
@@ -29,9 +29,19 @@ public interface GradleFile extends ProjectFile<GradleFile> {
     }
 
     @Override
+    default GradleFile overwrite(@Language("Gradle") String text) {
+        return ProjectFile.super.overwrite(text);
+    }
+
+    @Override
     @FormatMethod
     default GradleFile append(@Language("Gradle") @FormatString String text, Object... args) {
         return ProjectFile.super.append(text, args);
+    }
+
+    @Override
+    default GradleFile append(@Language("Gradle") String text) {
+        return ProjectFile.super.append(text);
     }
 
     @Override
@@ -44,6 +54,11 @@ public interface GradleFile extends ProjectFile<GradleFile> {
     @FormatMethod
     default GradleFile prepend(@Language("Gradle") @FormatString String text, Object... args) {
         return ProjectFile.super.prepend(text, args);
+    }
+
+    @Override
+    default GradleFile prepend(@Language("Gradle") String text) {
+        return ProjectFile.super.prepend(text);
     }
 
     @Override

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
@@ -16,32 +16,37 @@
 
 package com.palantir.gradle.testing.files.gradle;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import com.palantir.gradle.testing.files.ProjectFile;
 import org.intellij.lang.annotations.Language;
 
 public interface GradleFile extends ProjectFile<GradleFile> {
     @Override
-    default GradleFile overwrite(@Language("Gradle") String text) {
-        return ProjectFile.super.overwrite(text);
+    @FormatMethod
+    default GradleFile overwrite(@Language("Gradle") @FormatString String text, Object... args) {
+        return ProjectFile.super.overwrite(text, args);
     }
 
     @Override
-    default GradleFile append(@Language("Gradle") String text) {
-        return ProjectFile.super.append(text);
+    @FormatMethod
+    default GradleFile append(@Language("Gradle") @FormatString String text, Object... args) {
+        return ProjectFile.super.append(text, args);
     }
 
     @Override
-    default GradleFile appendLine(@Language("Gradle") String line) {
-        return ProjectFile.super.appendLine(line);
+    default GradleFile appendLine(@Language("Gradle") String line, Object... args) {
+        return ProjectFile.super.appendLine(line, args);
     }
 
     @Override
-    default GradleFile prepend(@Language("Gradle") String text) {
-        return ProjectFile.super.prepend(text);
+    @FormatMethod
+    default GradleFile prepend(@Language("Gradle") @FormatString String text, Object... args) {
+        return ProjectFile.super.prepend(text, args);
     }
 
     @Override
-    default GradleFile prependLine(@Language("Gradle") String line) {
-        return ProjectFile.super.prependLine(line);
+    default GradleFile prependLine(@Language("Gradle") String line, Object... args) {
+        return ProjectFile.super.prependLine(line, args);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/SettingsGradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/SettingsGradleFile.java
@@ -36,20 +36,20 @@ public record SettingsGradleFile(Path path) implements GradleFile {
                     .collect(Collectors.joining("\n"));
         });
 
-        prependLine("rootProject.name = '%s'".formatted(rootProjectName));
+        prependLine("rootProject.name = '%s'", rootProjectName);
 
         return this;
     }
 
     public SettingsGradleFile include(String projectPath) {
         @Language("Gradle")
-        String includeLine = "include '%s'".formatted(projectPath);
+        String includeLine = "include '%s'";
 
-        if (Files.exists(path) && text().contains(includeLine)) {
+        if (Files.exists(path) && text().contains(includeLine.formatted(projectPath))) {
             return this;
         }
 
-        appendLine(includeLine);
+        appendLine(includeLine, projectPath);
         return this;
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/java/JavaFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/java/JavaFile.java
@@ -35,9 +35,19 @@ public record JavaFile(Path path) implements ProjectFile<JavaFile> {
     }
 
     @Override
+    public JavaFile overwrite(@Language("Java") String text) {
+        return ProjectFile.super.overwrite(text);
+    }
+
+    @Override
     @FormatMethod
     public JavaFile append(@Language("Java") @FormatString String text, Object... args) {
         return ProjectFile.super.append(text, args);
+    }
+
+    @Override
+    public JavaFile append(@Language("Java") String text) {
+        return ProjectFile.super.append(text);
     }
 
     @Override
@@ -50,6 +60,11 @@ public record JavaFile(Path path) implements ProjectFile<JavaFile> {
     @FormatMethod
     public JavaFile prepend(@Language("Java") @FormatString String text, Object... args) {
         return ProjectFile.super.prepend(text, args);
+    }
+
+    @Override
+    public JavaFile prepend(@Language("Java") String text) {
+        return ProjectFile.super.prepend(text);
     }
 
     @Override

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/java/JavaFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/java/JavaFile.java
@@ -41,7 +41,8 @@ public record JavaFile(Path path) implements ProjectFile<JavaFile> {
     }
 
     @Override
-    public JavaFile appendLine(@Language("Java") String line, Object... args) {
+    @FormatMethod
+    public JavaFile appendLine(@Language("Java") @FormatString String line, Object... args) {
         return ProjectFile.super.appendLine(line, args);
     }
 
@@ -52,7 +53,8 @@ public record JavaFile(Path path) implements ProjectFile<JavaFile> {
     }
 
     @Override
-    public JavaFile prependLine(@Language("Java") String line, Object... args) {
+    @FormatMethod
+    public JavaFile prependLine(@Language("Java") @FormatString String line, Object... args) {
         return ProjectFile.super.prependLine(line, args);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/java/JavaFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/java/JavaFile.java
@@ -16,6 +16,8 @@
 
 package com.palantir.gradle.testing.files.java;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.files.ProjectFile;
@@ -27,27 +29,30 @@ public record JavaFile(Path path) implements ProjectFile<JavaFile> {
     public JavaFile {}
 
     @Override
-    public JavaFile overwrite(@Language("Java") String text) {
-        return ProjectFile.super.overwrite(text);
+    @FormatMethod
+    public JavaFile overwrite(@Language("Java") @FormatString String text, Object... args) {
+        return ProjectFile.super.overwrite(text, args);
     }
 
     @Override
-    public JavaFile append(@Language("Java") String text) {
-        return ProjectFile.super.append(text);
+    @FormatMethod
+    public JavaFile append(@Language("Java") @FormatString String text, Object... args) {
+        return ProjectFile.super.append(text, args);
     }
 
     @Override
-    public JavaFile appendLine(@Language("Java") String line) {
-        return ProjectFile.super.appendLine(line);
+    public JavaFile appendLine(@Language("Java") String line, Object... args) {
+        return ProjectFile.super.appendLine(line, args);
     }
 
     @Override
-    public JavaFile prepend(@Language("Java") String text) {
-        return ProjectFile.super.prepend(text);
+    @FormatMethod
+    public JavaFile prepend(@Language("Java") @FormatString String text, Object... args) {
+        return ProjectFile.super.prepend(text, args);
     }
 
     @Override
-    public JavaFile prependLine(@Language("Java") String line) {
-        return ProjectFile.super.prependLine(line);
+    public JavaFile prependLine(@Language("Java") String line, Object... args) {
+        return ProjectFile.super.prependLine(line, args);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/java/JavaSrcDir.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/java/JavaSrcDir.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.testing.files.java;
 
+import com.google.errorprone.annotations.FormatMethod;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import java.nio.file.Path;
@@ -32,7 +33,8 @@ public record JavaSrcDir(Path srcDirPath) {
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
     public JavaSrcDir {}
 
-    public JavaFile writeClass(@Language("Java") String javaSource) {
+    @FormatMethod
+    public JavaFile writeClass(@Language("Java") String javaSource, Object... args) {
         Optional<String> possiblePackagePath = possiblyExtractGroup(PACKAGE_PATTERN, javaSource);
 
         String className = possiblyExtractGroup(CLASS_PATTERN, javaSource)
@@ -42,7 +44,7 @@ public record JavaSrcDir(Path srcDirPath) {
         String canonicalClassName =
                 possiblePackagePath.map(packagePath -> packagePath + ".").orElse("") + className;
 
-        return fileByClassName(canonicalClassName).overwrite(javaSource);
+        return fileByClassName(canonicalClassName).overwrite(javaSource, args);
     }
 
     public JavaFile fileByClassName(String canonicalClassName) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -29,7 +29,7 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     public PropertiesFile {}
 
     public PropertiesFile appendProperty(String key, String value) {
-        return appendLine("%s=%s".formatted(key, value));
+        return appendLine("%s=%s", key, value);
     }
 
     @Override
@@ -45,7 +45,8 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     }
 
     @Override
-    public PropertiesFile appendLine(@Language("Properties") String line, Object... args) {
+    @FormatMethod
+    public PropertiesFile appendLine(@Language("Properties") @FormatString String line, Object... args) {
         return ProjectFile.super.appendLine(line, args);
     }
 
@@ -56,7 +57,8 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     }
 
     @Override
-    public PropertiesFile prependLine(@Language("Properties") String line, Object... args) {
+    @FormatMethod
+    public PropertiesFile prependLine(@Language("Properties") @FormatString String line, Object... args) {
         return ProjectFile.super.prependLine(line, args);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -16,6 +16,8 @@
 
 package com.palantir.gradle.testing.files.properties;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.files.ProjectFile;
@@ -31,27 +33,30 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     }
 
     @Override
-    public PropertiesFile overwrite(@Language("Properties") String text) {
-        return ProjectFile.super.overwrite(text);
+    @FormatMethod
+    public PropertiesFile overwrite(@Language("Properties") @FormatString String text, Object... args) {
+        return ProjectFile.super.overwrite(text, args);
     }
 
     @Override
-    public PropertiesFile append(@Language("Properties") String text) {
-        return ProjectFile.super.append(text);
+    @FormatMethod
+    public PropertiesFile append(@Language("Properties") @FormatString String text, Object... args) {
+        return ProjectFile.super.append(text, args);
     }
 
     @Override
-    public PropertiesFile appendLine(@Language("Properties") String line) {
-        return ProjectFile.super.appendLine(line);
+    public PropertiesFile appendLine(@Language("Properties") String line, Object... args) {
+        return ProjectFile.super.appendLine(line, args);
     }
 
     @Override
-    public PropertiesFile prepend(@Language("Properties") String text) {
-        return ProjectFile.super.prepend(text);
+    @FormatMethod
+    public PropertiesFile prepend(@Language("Properties") @FormatString String text, Object... args) {
+        return ProjectFile.super.prepend(text, args);
     }
 
     @Override
-    public PropertiesFile prependLine(@Language("Properties") String line) {
-        return ProjectFile.super.prependLine(line);
+    public PropertiesFile prependLine(@Language("Properties") String line, Object... args) {
+        return ProjectFile.super.prependLine(line, args);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -39,9 +39,19 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     }
 
     @Override
+    public PropertiesFile overwrite(@Language("Properties") String text) {
+        return ProjectFile.super.overwrite(text);
+    }
+
+    @Override
     @FormatMethod
     public PropertiesFile append(@Language("Properties") @FormatString String text, Object... args) {
         return ProjectFile.super.append(text, args);
+    }
+
+    @Override
+    public PropertiesFile append(@Language("Properties") String text) {
+        return ProjectFile.super.append(text);
     }
 
     @Override
@@ -54,6 +64,11 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     @FormatMethod
     public PropertiesFile prepend(@Language("Properties") @FormatString String text, Object... args) {
         return ProjectFile.super.prepend(text, args);
+    }
+
+    @Override
+    public PropertiesFile prepend(@Language("Properties") String text) {
+        return ProjectFile.super.prepend(text);
     }
 
     @Override

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/yaml/YamlFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/yaml/YamlFile.java
@@ -35,9 +35,19 @@ public record YamlFile(Path path) implements ProjectFile<YamlFile> {
     }
 
     @Override
+    public YamlFile overwrite(@Language("YAML") String text) {
+        return ProjectFile.super.overwrite(text);
+    }
+
+    @Override
     @FormatMethod
     public YamlFile append(@Language("YAML") @FormatString String text, Object... args) {
         return ProjectFile.super.append(text, args);
+    }
+
+    @Override
+    public YamlFile append(@Language("YAML") String text) {
+        return ProjectFile.super.append(text);
     }
 
     @Override
@@ -50,6 +60,11 @@ public record YamlFile(Path path) implements ProjectFile<YamlFile> {
     @FormatMethod
     public YamlFile prepend(@Language("YAML") @FormatString String text, Object... args) {
         return ProjectFile.super.prepend(text, args);
+    }
+
+    @Override
+    public YamlFile prepend(@Language("YAML") String text) {
+        return ProjectFile.super.prepend(text);
     }
 
     @Override

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/yaml/YamlFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/yaml/YamlFile.java
@@ -16,6 +16,8 @@
 
 package com.palantir.gradle.testing.files.yaml;
 
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.files.ProjectFile;
@@ -27,27 +29,30 @@ public record YamlFile(Path path) implements ProjectFile<YamlFile> {
     public YamlFile {}
 
     @Override
-    public YamlFile overwrite(@Language("YAML") String text) {
-        return ProjectFile.super.overwrite(text);
+    @FormatMethod
+    public YamlFile overwrite(@Language("YAML") @FormatString String text, Object... args) {
+        return ProjectFile.super.overwrite(text, args);
     }
 
     @Override
-    public YamlFile append(@Language("YAML") String text) {
-        return ProjectFile.super.append(text);
+    @FormatMethod
+    public YamlFile append(@Language("YAML") @FormatString String text, Object... args) {
+        return ProjectFile.super.append(text, args);
     }
 
     @Override
-    public YamlFile appendLine(@Language("YAML") String line) {
-        return ProjectFile.super.appendLine(line);
+    public YamlFile appendLine(@Language("YAML") String line, Object... args) {
+        return ProjectFile.super.appendLine(line, args);
     }
 
     @Override
-    public YamlFile prepend(@Language("YAML") String text) {
-        return ProjectFile.super.prepend(text);
+    @FormatMethod
+    public YamlFile prepend(@Language("YAML") @FormatString String text, Object... args) {
+        return ProjectFile.super.prepend(text, args);
     }
 
     @Override
-    public YamlFile prependLine(@Language("YAML") String line) {
-        return ProjectFile.super.prependLine(line);
+    public YamlFile prependLine(@Language("YAML") String line, Object... args) {
+        return ProjectFile.super.prependLine(line, args);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/yaml/YamlFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/yaml/YamlFile.java
@@ -41,7 +41,8 @@ public record YamlFile(Path path) implements ProjectFile<YamlFile> {
     }
 
     @Override
-    public YamlFile appendLine(@Language("YAML") String line, Object... args) {
+    @FormatMethod
+    public YamlFile appendLine(@Language("YAML") @FormatString String line, Object... args) {
         return ProjectFile.super.appendLine(line, args);
     }
 
@@ -52,7 +53,8 @@ public record YamlFile(Path path) implements ProjectFile<YamlFile> {
     }
 
     @Override
-    public YamlFile prependLine(@Language("YAML") String line, Object... args) {
+    @FormatMethod
+    public YamlFile prependLine(@Language("YAML") @FormatString String line, Object... args) {
         return ProjectFile.super.prependLine(line, args);
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/assertions/GradleAssertionsTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/assertions/GradleAssertionsTest.java
@@ -1,0 +1,142 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.assertions;
+
+import static com.palantir.gradle.testing.assertions.GradleAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.execution.InvocationResult;
+import com.palantir.gradle.testing.execution.TaskOutcome;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+class GradleAssertionsTest {
+
+    @Test
+    void can_use_fluent_assertions_for_task_outcome_not_in(GradleInvoker gradle, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            tasks.register('foo') {
+                outputs.file('foo.txt')
+                doLast {
+                    file('foo.txt').text = 'hello'
+                }
+            }
+            """);
+
+        InvocationResult firstRun = gradle.withArgs("foo").buildsSuccessfully();
+        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+
+        assertThat(firstRun)
+                .task(":foo")
+                .as("First run should execute the task")
+                .hasOutcome()
+                .as("First run task outcome should not be cached")
+                .isNotIn(TaskOutcome.UP_TO_DATE, TaskOutcome.FROM_CACHE);
+
+        assertThat(secondRun)
+                .task(":foo")
+                .as("Second run should have task cached")
+                .hasOutcome()
+                .as("Second run task outcome should be cached")
+                .isIn(TaskOutcome.UP_TO_DATE, TaskOutcome.FROM_CACHE);
+    }
+
+    @Test
+    void can_use_fluent_assertions_for_task_path(GradleInvoker gradle, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            tasks.register('foo') {
+                doLast {}
+            }
+            """);
+
+        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+        assertThat(result).task(":foo").as("Task should have correct path").hasPath(":foo");
+    }
+
+    @Test
+    void can_use_fluent_assertions_for_output(GradleInvoker gradle, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            println 'hello from build'
+            """);
+
+        InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+        assertThat(result).as("Build output should contain expected message").hasOutput("hello from build");
+    }
+
+    @Test
+    void fluent_assertions_fail_when_outcome_is_in_excluded_list(GradleInvoker gradle, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            tasks.register('foo') {
+                // No action - will be UP_TO_DATE
+            }
+            """);
+
+        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+        assertThatThrownBy(() -> assertThat(result)
+                        .task(":foo")
+                        .as("Task should be present")
+                        .hasOutcome()
+                        .as("Task outcome validation")
+                        .isNotIn(TaskOutcome.UP_TO_DATE, TaskOutcome.FROM_CACHE))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected task outcome not to be in");
+    }
+
+    @Test
+    void fluent_assertions_fail_when_outcome_is_not_in_expected_list(GradleInvoker gradle, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            tasks.register('foo') {
+                doLast {}
+            }
+            """);
+
+        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+        assertThatThrownBy(() -> assertThat(result)
+                        .task(":foo")
+                        .as("Task should be present")
+                        .hasOutcome()
+                        .as("Task outcome validation")
+                        .isIn(TaskOutcome.UP_TO_DATE, TaskOutcome.FROM_CACHE))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Expected task outcome to be in");
+    }
+
+    @Test
+    void fluent_assertions_fail_when_task_is_not_present(GradleInvoker gradle) {
+        InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+        assertThatThrownBy(() -> assertThat(result)
+                        .task(":nonexistent")
+                        .as("Task should not be present")
+                        .hasOutcome())
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void can_check_task_is_empty(GradleInvoker gradle) {
+        InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+        assertThat(result).task(":nonexistent").as("Non-existent task should be empty").isEmpty();
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/assertions/GradleAssertionsTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/assertions/GradleAssertionsTest.java
@@ -137,6 +137,9 @@ class GradleAssertionsTest {
     void can_check_task_is_empty(GradleInvoker gradle) {
         InvocationResult result = gradle.withArgs().buildsSuccessfully();
 
-        assertThat(result).task(":nonexistent").as("Non-existent task should be empty").isEmpty();
+        assertThat(result)
+                .task(":nonexistent")
+                .as("Non-existent task should be empty")
+                .isEmpty();
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/DirectoryTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/DirectoryTest.java
@@ -1,0 +1,87 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+class DirectoryTest {
+
+    @Test
+    void can_create_directory(RootProject rootProject) {
+        Directory dir = rootProject.directory("my-dir");
+
+        dir.assertThat().isDirectory();
+    }
+
+    @Test
+    void can_create_nested_directories(RootProject rootProject) {
+        Directory dir = rootProject.directory("foo/bar/baz");
+
+        dir.assertThat().isDirectory();
+    }
+
+    @Test
+    void can_create_files_in_directory(RootProject rootProject) {
+        Directory dir = rootProject.directory("my-dir");
+
+        dir.file("test.txt").overwrite("hello");
+
+        assertThat(dir.file("test.txt").text()).isEqualTo("hello");
+    }
+
+    @Test
+    void directory_implements_file_factory(RootProject rootProject) {
+        Directory dir = rootProject.directory("my-dir");
+
+        dir.file("file.txt").overwrite("file content");
+        dir.gradleFile("build.gradle").append("plugins { id 'java' }");
+        dir.yamlFile("config.yaml").overwrite("key: value");
+        dir.propertiesFile("gradle.properties").overwrite("property=value");
+
+        assertThat(dir.file("file.txt").text()).isEqualTo("file content");
+        assertThat(dir.gradleFile("build.gradle").text()).contains("plugins { id 'java' }");
+        assertThat(dir.yamlFile("config.yaml").text()).isEqualTo("key: value");
+        assertThat(dir.propertiesFile("gradle.properties").text()).isEqualTo("property=value");
+    }
+
+    @Test
+    void can_create_nested_directories_in_directory(RootProject rootProject) {
+        Directory parentDir = rootProject.directory("parent");
+        Directory childDir = parentDir.directory("child");
+
+        childDir.assertThat().isDirectory();
+        childDir.file("test.txt").overwrite("nested");
+
+        assertThat(childDir.file("test.txt").text()).isEqualTo("nested");
+    }
+
+    @Test
+    void directory_does_not_need_to_be_created_to_add_files(RootProject rootProject) {
+        Directory dir = rootProject.directory("my-dir");
+
+        // Files will create parent directories automatically
+        dir.file("test.txt").overwrite("content");
+
+        dir.assertThat().isDirectory();
+        assertThat(dir.file("test.txt").text()).isEqualTo("content");
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/ProjectFileFormattingTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/ProjectFileFormattingTest.java
@@ -1,0 +1,122 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+class ProjectFileFormattingTest {
+
+    @Test
+    void can_format_overwrite(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("""
+            tasks.register('%s') {
+                doLast {}
+            }
+            """, "myTask");
+
+        assertThat(rootProject.buildGradle().text()).contains("tasks.register('myTask')");
+    }
+
+    @Test
+    void can_format_append(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("plugins { id 'java' }\n");
+        rootProject.buildGradle().append("""
+            tasks.register('%s') {
+                doLast {}
+            }
+            """, "myTask");
+
+        assertThat(rootProject.buildGradle().text())
+                .contains("plugins { id 'java' }")
+                .contains("tasks.register('myTask')");
+    }
+
+    @Test
+    void can_format_appendLine(RootProject rootProject) {
+        rootProject.buildGradle().appendLine("version = '%s'", "1.0.0");
+
+        assertThat(rootProject.buildGradle().text()).isEqualTo("version = '1.0.0'\n");
+    }
+
+    @Test
+    void can_format_prepend(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("task foo {}\n");
+        rootProject.buildGradle().prepend("""
+            tasks.register('%s') {
+                doLast {}
+            }
+            """, "myTask");
+
+        assertThat(rootProject.buildGradle().text()).startsWith("tasks.register('myTask')");
+    }
+
+    @Test
+    void can_format_prependLine(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("task foo {}");
+        rootProject.buildGradle().prependLine("version = '%s'", "1.0.0");
+
+        assertThat(rootProject.buildGradle().text()).startsWith("version = '1.0.0'\n");
+    }
+
+    @Test
+    void can_format_with_multiple_arguments(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("""
+            tasks.register('%s') {
+                group = '%s'
+                description = '%s'
+            }
+            """, "myTask", "build", "My custom task");
+
+        assertThat(rootProject.buildGradle().text())
+                .contains("tasks.register('myTask')")
+                .contains("group = 'build'")
+                .contains("description = 'My custom task'");
+    }
+
+    @Test
+    void works_without_format_arguments(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("""
+            tasks.register('myTask') {
+                doLast {}
+            }
+            """);
+
+        assertThat(rootProject.buildGradle().text()).contains("tasks.register('myTask')");
+    }
+
+    @Test
+    void formatting_preserves_language_injection_in_ide(RootProject rootProject) {
+        // This test documents that by using varargs instead of .formatted(),
+        // IDE language injections are preserved in the text block
+        String taskName = "customTask";
+
+        rootProject.buildGradle().append("""
+            tasks.register('%s') {
+                doLast {
+                    println 'Hello from task'
+                }
+            }
+            """, taskName);
+
+        assertThat(rootProject.buildGradle().text()).contains("tasks.register('customTask')");
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/ProjectFileFormattingTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/ProjectFileFormattingTest.java
@@ -37,6 +37,17 @@ class ProjectFileFormattingTest {
     }
 
     @Test
+    void can_format_override_manually(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("""
+            tasks.register('%s') {
+                doLast {}
+            }
+            """.formatted("myTask"));
+
+        assertThat(rootProject.buildGradle().text()).contains("tasks.register('myTask')");
+    }
+
+    @Test
     void can_format_append(RootProject rootProject) {
         rootProject.buildGradle().overwrite("plugins { id 'java' }\n");
         rootProject.buildGradle().append("""
@@ -51,8 +62,29 @@ class ProjectFileFormattingTest {
     }
 
     @Test
+    void can_format_append_manually(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("plugins { id 'java' }\n");
+        rootProject.buildGradle().append("""
+            tasks.register('%s') {
+                doLast {}
+            }
+            """.formatted("myTask"));
+
+        assertThat(rootProject.buildGradle().text())
+                .contains("plugins { id 'java' }")
+                .contains("tasks.register('myTask')");
+    }
+
+    @Test
     void can_format_appendLine(RootProject rootProject) {
         rootProject.buildGradle().appendLine("version = '%s'", "1.0.0");
+
+        assertThat(rootProject.buildGradle().text()).isEqualTo("version = '1.0.0'\n");
+    }
+
+    @Test
+    void can_format_appendLine_manually(RootProject rootProject) {
+        rootProject.buildGradle().appendLine("version = '%s'".formatted("1.0.0"));
 
         assertThat(rootProject.buildGradle().text()).isEqualTo("version = '1.0.0'\n");
     }
@@ -70,9 +102,29 @@ class ProjectFileFormattingTest {
     }
 
     @Test
+    void can_format_prepend_manually(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("task foo {}\n");
+        rootProject.buildGradle().prepend("""
+            tasks.register('%s') {
+                doLast {}
+            }
+            """.formatted("myTask"));
+
+        assertThat(rootProject.buildGradle().text()).startsWith("tasks.register('myTask')");
+    }
+
+    @Test
     void can_format_prependLine(RootProject rootProject) {
         rootProject.buildGradle().overwrite("task foo {}");
         rootProject.buildGradle().prependLine("version = '%s'", "1.0.0");
+
+        assertThat(rootProject.buildGradle().text()).startsWith("version = '1.0.0'\n");
+    }
+
+    @Test
+    void can_format_prependLine_manually(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("task foo {}");
+        rootProject.buildGradle().prependLine("version = '%s'".formatted("1.0.0"));
 
         assertThat(rootProject.buildGradle().text()).startsWith("version = '1.0.0'\n");
     }


### PR DESCRIPTION
  ## Before this PR
  <!-- What's wrong with the current state of the world and why change it now? -->

  Test assertions for Gradle invocations were verbose and not fluent - developers had to manually extract task results and write assertion logic, making test code harder to read and maintain.

Using `.formatted()` breaks IDE language injection - the IDE cannot provide syntax highlighting for the string content (e.g., Gradle DSL in build files).

  There was no first-class support for creating and working with directories as test fixtures.

  ## After this PR
  <!-- User-facing outcomes this PR delivers go below -->

  ### Custom Gradle Assertions (assertions package)
  New fluent AssertJ-style assertions for Gradle plugin testing:

  **GradleAssertions.java** - Entry point for custom assertions
  - `assertThat(InvocationResult)` - Start fluent assertion chain

  **InvocationResultAssert.java** - Assertions for build results
  - `task(String taskPath)` - Select a task for assertion
  - `hasOutput(String expectedOutput)` - Assert build output contains text
  - `TaskResultOptionalAssert` - Fluent assertions for task results with `hasOutcome()` and `hasPath()`

  **TaskOutcomeAssert.java** - Assertions for task execution outcomes
  - `isIn(TaskOutcome... expectedOutcomes)` - Assert outcome is in set
  - `isNotIn(TaskOutcome... excludedOutcomes)` - Assert outcome is not in set

  **TaskResultAssert.java** - Assertions for task results
  - `hasOutcome()` - Get outcome assertions
  - `hasPath(String expectedPath)` - Assert task path

  **GradleAssertionsTest.java** - Comprehensive tests demonstrating usage patterns

  **Example usage:**
  ```java
  // Before - verbose and manual
  InvocationResult result = gradle.withArgs("myTask").buildsSuccessfully();
  Optional<TaskResult> taskResult = result.task(":myTask");
  assertTrue(taskResult.isPresent());
  TaskOutcome outcome = taskResult.get().outcome();
  assertFalse(outcome == TaskOutcome.UP_TO_DATE || outcome == TaskOutcome.FROM_CACHE);

  // After - fluent and readable
  import static com.palantir.gradle.testing.assertions.GradleAssertions.assertThat;

  InvocationResult result = gradle.withArgs("myTask").buildsSuccessfully();
  assertThat(result)
      .task(":myTask")
      .hasOutcome()
      .isNotIn(TaskOutcome.UP_TO_DATE, TaskOutcome.FROM_CACHE);
```

  ### File Formatting Support (files package)
  All `ProjectFile` implementations now support Java's `String.formatted()` syntax via varargs, **preserving IDE language injection and syntax highlighting**:

  **ProjectFile.java** - Base formatting methods
  - `overwrite(String text, Object... args)`
  - `append(String text, Object... args)`
  - `appendLine(String line, Object... args)`
  - `prepend(String text, Object... args)`
  - `prependLine(String line, Object... args)`

  **Type-specific files with @Language annotations preserved**
  - **GradleFile.java** - All methods with `@Language("Gradle")` + `@FormatString`
  - **JavaFile.java** - All methods with `@Language("Java")` + `@FormatString`
  - **PropertiesFile.java** - All methods with `@Language("Properties")` + `@FormatString`
  - **YamlFile.java** - All methods with `@Language("YAML")` + `@FormatString`
  - **JavaSrcDir.java** - `writeClass()` supports formatting
  - **SettingsGradleFile.java** - Updated to use new formatting methods

  **ProjectFileFormattingTest.java** - Tests demonstrating both approaches work, with a test explicitly documenting the IDE benefit

  **Example usage:**
```java
  // Before - loses syntax highlighting after .formatted()
  String taskName = "myCustomTask";
  rootProject.buildGradle().append("""
      tasks.register('%s') {
          doLast {
              println 'Hello'
          }
      }
      """.formatted(taskName));  // No Gradle syntax highlighting in IDE

  // After - preserves syntax highlighting with varargs
  String taskName = "myCustomTask";
  rootProject.buildGradle().append("""
      tasks.register('%s') {
          doLast {
              println 'Hello'
          }
      }
      """, taskName);  // Full Gradle syntax highlighting in IDE
```
  ### Directory API (files package)
  New `Directory` record for working with test directories:

  **Directory.java**
  - Automatically creates directories on instantiation
  - Implements `FileFactory` for creating files within directories
  - Provides `assertThat()` for path assertions
  - Accessible via `directory(String path)` on any `FileFactory`

  **DirectoryTest.java** - Tests for directory operations

  **Example usage:**
```java
  // Create directories and files within them
  Directory subDir = rootProject.directory("src/main/resources");
  subDir.file("config.properties").overwrite("key=value");
  subDir.yamlFile("settings.yaml").overwrite("enabled: true");

  // Nested directories
  Directory parent = rootProject.directory("parent");
  Directory child = parent.directory("child");
  child.file("test.txt").overwrite("content");

  // Assertions on directories
  Directory dir = rootProject.directory("my-dir");
  dir.assertThat().isDirectory().exists();
```
  ==COMMIT_MSG==
  Add custom AssertJ assertions, formatting, and Directory API

  - Add GradleAssertions fluent API for InvocationResult and TaskOutcome
  - Add @FormatMethod overloads to ProjectFile preserving IDE language injection
  - Implement Directory record with FileFactory interface
  - Add comprehensive tests for all new functionality
 
 ==COMMIT_MSG==

  ## Possible downsides?
  <!-- Please describe any way users could be negatively affected by this PR. -->

  None expected. All changes are additive