### PR TITLE
Add `addDependency` method to `GradleFile`

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
@@ -17,6 +17,8 @@
 package com.palantir.gradle.testing.files.gradle;
 
 import com.palantir.gradle.testing.files.ProjectFile;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.intellij.lang.annotations.Language;
 
 public interface GradleFile extends ProjectFile<GradleFile> {
@@ -43,5 +45,30 @@ public interface GradleFile extends ProjectFile<GradleFile> {
     @Override
     default GradleFile prependLine(@Language("Gradle") String line) {
         return ProjectFile.super.prependLine(line);
+    }
+
+    /**
+     * Adds dependencies to the dependencies block using the 'implementation' configuration.
+     * Example: {@code buildGradle().addDependencies("com.google.guava:guava:31.1-jre")}
+     */
+    default GradleFile addDependencies(String... dependencies) {
+        return addDependency("implementation", dependencies);
+    }
+
+    /**
+     * Adds a dependency to the dependencies block with a specific configuration (string-based).
+     * Example: {@code buildGradle().addDependency("testImplementation", "junit:junit:4.13.2")}
+     *
+     * @param configuration the Gradle configuration (e.g., "implementation", "testImplementation", "api")
+     * @param dependencies the dependency coordinates
+     */
+    default GradleFile addDependency(String configuration, String... dependencies) {
+        if (dependencies.length == 0) {
+            return this;
+        }
+
+        return appendLine(Arrays.stream(dependencies)
+                .map(dep -> "    " + configuration + " '" + dep + "'")
+                .collect(Collectors.joining("\n", "dependencies {\n", "\n}")));
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/GradleFile.java
@@ -48,16 +48,8 @@ public interface GradleFile extends ProjectFile<GradleFile> {
     }
 
     /**
-     * Adds dependencies to the dependencies block using the 'implementation' configuration.
-     * Example: {@code buildGradle().addDependencies("com.google.guava:guava:31.1-jre")}
-     */
-    default GradleFile addDependencies(String... dependencies) {
-        return addDependency("implementation", dependencies);
-    }
-
-    /**
-     * Adds a dependency to the dependencies block with a specific configuration (string-based).
-     * Example: {@code buildGradle().addDependency("testImplementation", "junit:junit:4.13.2")}
+     * Adds dependencies to the dependencies block with a specific configuration.
+     * Example: {@code buildGradle().addDependency("implementation", "com.google.guava:guava:31.1-jre")}
      *
      * @param configuration the Gradle configuration (e.g., "implementation", "testImplementation", "api")
      * @param dependencies the dependency coordinates

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/GradleFileTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/GradleFileTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 class GradleFileTest {
     @Test
     void addDependencies_single_dependency_with_default_configuration(RootProject rootProject) {
-        rootProject.buildGradle().addDependencies("com.google.guava:guava:31.1-jre");
+        rootProject.buildGradle().addDependency("implementation", "com.google.guava:guava:31.1-jre");
 
         assertThat(rootProject.buildGradle().text()).contains("""
             dependencies {
@@ -37,7 +37,7 @@ class GradleFileTest {
 
     @Test
     void addDependencies_multiple_dependencies_with_default_configuration(RootProject rootProject) {
-        rootProject.buildGradle().addDependencies("com.google.guava:guava:31.1-jre", "org.slf4j:slf4j-api:2.0.0");
+        rootProject.buildGradle().addDependency("implementation", "com.google.guava:guava:31.1-jre", "org.slf4j:slf4j-api:2.0.0");
 
         assertThat(rootProject.buildGradle().text()).contains("""
             dependencies {
@@ -62,7 +62,7 @@ class GradleFileTest {
     void addDependencies_can_be_chained(RootProject rootProject) {
         rootProject
                 .buildGradle()
-                .addDependencies("com.google.guava:guava:31.1-jre")
+                .addDependency("implementation", "com.google.guava:guava:31.1-jre")
                 .addDependency("testImplementation", "junit:junit:4.13.2");
 
         assertThat(rootProject.buildGradle().text()).contains("""

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/GradleFileTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/GradleFileTest.java
@@ -1,0 +1,91 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.files.gradle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+class GradleFileTest {
+    @Test
+    void addDependencies_single_dependency_with_default_configuration(RootProject rootProject) {
+        rootProject.buildGradle().addDependencies("com.google.guava:guava:31.1-jre");
+
+        assertThat(rootProject.buildGradle().text()).contains("""
+            dependencies {
+                implementation 'com.google.guava:guava:31.1-jre'
+            }
+            """);
+    }
+
+    @Test
+    void addDependencies_multiple_dependencies_with_default_configuration(RootProject rootProject) {
+        rootProject.buildGradle().addDependencies("com.google.guava:guava:31.1-jre", "org.slf4j:slf4j-api:2.0.0");
+
+        assertThat(rootProject.buildGradle().text()).contains("""
+            dependencies {
+                implementation 'com.google.guava:guava:31.1-jre'
+                implementation 'org.slf4j:slf4j-api:2.0.0'
+            }
+            """);
+    }
+
+    @Test
+    void addDependency_with_custom_configuration(RootProject rootProject) {
+        rootProject.buildGradle().addDependency("testImplementation", "junit:junit:4.13.2");
+
+        assertThat(rootProject.buildGradle().text()).contains("""
+            dependencies {
+                testImplementation 'junit:junit:4.13.2'
+            }
+            """);
+    }
+
+    @Test
+    void addDependencies_can_be_chained(RootProject rootProject) {
+        rootProject
+                .buildGradle()
+                .addDependencies("com.google.guava:guava:31.1-jre")
+                .addDependency("testImplementation", "junit:junit:4.13.2");
+
+        assertThat(rootProject.buildGradle().text()).contains("""
+            dependencies {
+                implementation 'com.google.guava:guava:31.1-jre'
+            }
+            dependencies {
+                testImplementation 'junit:junit:4.13.2'
+            }
+            """);
+    }
+
+    @Test
+    void addDependency_with_multiple_dependencies_using_varargs(RootProject rootProject) {
+        rootProject
+                .buildGradle()
+                .addDependency("testImplementation", "junit:junit:4.13.2", "org.mockito:mockito-core:4.8.0");
+
+        assertThat(rootProject.buildGradle().text()).contains("""
+            dependencies {
+                testImplementation 'junit:junit:4.13.2'
+                testImplementation 'org.mockito:mockito-core:4.8.0'
+            }
+            """);
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/GradleFileTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/GradleFileTest.java
@@ -37,7 +37,9 @@ class GradleFileTest {
 
     @Test
     void addDependencies_multiple_dependencies_with_default_configuration(RootProject rootProject) {
-        rootProject.buildGradle().addDependency("implementation", "com.google.guava:guava:31.1-jre", "org.slf4j:slf4j-api:2.0.0");
+        rootProject
+                .buildGradle()
+                .addDependency("implementation", "com.google.guava:guava:31.1-jre", "org.slf4j:slf4j-api:2.0.0");
 
         assertThat(rootProject.buildGradle().text()).contains("""
             dependencies {


### PR DESCRIPTION
## Before this PR
Had no way to easily add dependencies to gradle files (a common operation)
## After this PR
Now a user can do 

```java
        rootProject
                .buildGradle()
                .addDependency("implementation", "com.google.guava:guava:31.1-jre")
                .addDependency("testImplementation", "junit:junit:4.13.2");
```
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `addDependency` method to `GradleFile`
==COMMIT_MSG==

## Possible downsides?
may be adding a rarely used method and confusing the API?
<!-- Please describe any way users could be negatively affected by this PR. -->

