### PR TITLE
Enable `withDebug` automatically in `@GradlePluginTests`

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
@@ -47,11 +47,9 @@ public final class GradleInvoker {
         //   -agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=127.0.0.1:54342
         // We can use this to detect whether we should run with Gradle tooling `.withDebug` or not,
         // `withDebug(true)` will run the Gradle tooling inside the same JVM as the test, meaning
-        // debugging works, whereas `withDebug(false)` will run Gradle in a new daemon. There can
+        // debugging works, whereas `withDebug(false)` will run Gradle in a new daemon. There can be
         // differences between these two modes!
-        return ManagementFactory.getRuntimeMXBean()
-                .getInputArguments()
-                .toString()
-                .contains("-agentlib:jdwp");
+        return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+                .anyMatch(s -> s.contains("-agentlib:jdwp"));
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.testing.execution;
 
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
+import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import org.gradle.testkit.runner.GradleRunner;
 
@@ -34,10 +35,23 @@ public final class GradleInvoker {
     public GradleInvocation withArgs(String... args) {
         return new GradleInvocation(GradleRunner.create()
                 .withProjectDir(rootProjectDir.toFile())
-                .withDebug(false)
+                .withDebug(isJavaDebugAgentLoaded())
                 .forwardOutput()
                 .withGradleVersion(gradleVersion.version())
                 .withPluginClasspath()
                 .withArguments(args));
+    }
+
+    private static boolean isJavaDebugAgentLoaded() {
+        // When you run a test with debug in intellij, it passes an arg to the test process like:
+        //   -agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=127.0.0.1:54342
+        // We can use this to detect whether we should run with Gradle tooling `.withDebug` or not,
+        // `withDebug(true)` will run the Gradle tooling inside the same JVM as the test, meaning
+        // debugging works, whereas `withDebug(false)` will run Gradle in a new daemon. There can
+        // differences between these two modes!
+        return ManagementFactory.getRuntimeMXBean()
+                .getInputArguments()
+                .toString()
+                .contains("-agentlib:jdwp");
     }
 }


### PR DESCRIPTION
## Before this PR
We always initialise the `GradleRunner` we use to actually run tests using `withDebug(false)`. This means it is impossible to debug Gradle plugin code running as part of the test.

## After this PR
==COMMIT_MSG==
Support debugging in  `@GradlePluginTests`
==COMMIT_MSG==

We do this by checking whether the `-agentlib:jdwp` is part of the runtime args for the test process - if it is, the test is running in debug mode and we should we should ensure that the Gradle tooling is setup to enable debugging.

This is the [same thing](https://github.com/nebula-plugins/nebula-test/blob/8f9bd580f375b5faf893c49303d1e9bdbb434062/src/main/groovy/nebula/test/IntegrationTestKitBase.groovy#L107) that [nebula-test does](https://github.com/nebula-plugins/nebula-test/blob/8f9bd580f375b5faf893c49303d1e9bdbb434062/src/main/groovy/nebula/test/IntegrationTestKitBase.groovy#L141-L145).

## Possible downsides?
`withDebug(true)` will run the Gradle tooling inside the same JVM as the test, meaning debugging works, whereas `withDebug(false)` will run Gradle in a new daemon. There can differences between these two modes! But not really much we can do here.

Cannot test this automatically in any striaightforward way, so have manually tested.
