### PR TITLE
Enable `--stacktrace` in GradleRunner by default

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
@@ -16,10 +16,12 @@
 
 package com.palantir.gradle.testing.execution;
 
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
+import java.util.Arrays;
 import org.gradle.testkit.runner.GradleRunner;
 
 public final class GradleInvoker {
@@ -33,13 +35,18 @@ public final class GradleInvoker {
     }
 
     public GradleInvocation withArgs(String... args) {
+        String[] argsWithStacktrace = ImmutableList.builder()
+                .addAll(Arrays.asList(args))
+                .add("--stacktrace")
+                .build()
+                .toArray(String[]::new);
         return new GradleInvocation(GradleRunner.create()
                 .withProjectDir(rootProjectDir.toFile())
                 .withDebug(isJavaDebugAgentLoaded())
                 .forwardOutput()
                 .withGradleVersion(gradleVersion.version())
                 .withPluginClasspath()
-                .withArguments(args));
+                .withArguments(argsWithStacktrace));
     }
 
     private static boolean isJavaDebugAgentLoaded() {

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -155,7 +155,11 @@ class GradleAssertionsUsageTest {
         rootProject.buildGradle().append("""
             tasks.register('foo') {
                 doLast {
-                    throw new RuntimeException('intentional failure')
+                    try {
+                        throw new IOException("Some exception")
+                    } catch (Exception e) {
+                        throw new RuntimeException('intentional failure', e)
+                    }
                 }
             }
             """);
@@ -163,6 +167,7 @@ class GradleAssertionsUsageTest {
         InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
 
         result.assertThat().task(":foo").failed();
+        assertThat(result).output().contains("Caused by: java.io.IOException: Some exception");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Adds the same behaviour as [nebula-test that adds by default "--stacktrace" arg ](https://github.com/nebula-plugins/nebula-test/blob/e9951b2732ce376f2cc951a9625063c9a2ff54a1/src/main/groovy/nebula/test/IntegrationBase.groovy#L268) when running the gradle tasks. 

==COMMIT_MSG==
Enable `--stacktrace` in GradleRunner by default
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

