### PR TITLE
Make it possible to use external plugins in the `plugins {}` block and have them auto-update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,6 @@ allprojects {
     }
 }
 
-
-
 javaVersions {
     libraryTarget = 17
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ allprojects {
     }
 }
 
+
+
 javaVersions {
     libraryTarget = 17
 }

--- a/gradle-plugin-testing/build.gradle
+++ b/gradle-plugin-testing/build.gradle
@@ -4,6 +4,15 @@ apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.gradle-plugin-testing'
 apply plugin: 'com.palantir.external-publish-gradle-plugin'
 
+// used for self bootstrapping - remove on next release and bump own version
+configurations {
+    gradlePluginForTesting
+}
+
+tasks.named("pluginUnderTestMetadata", PluginUnderTestMetadata) {
+    it.getPluginClasspath().from(configurations.named("gradlePluginForTesting"))
+}
+
 dependencies {
     implementation project(':plugin-testing-core')
     implementation 'com.palantir.baseline:gradle-baseline-java'
@@ -18,7 +27,7 @@ dependencies {
     testImplementation 'org.spockframework:spock-core'
 
     testRuntimeOnly 'com.google.guava:guava'
-    testRuntimeOnly 'com.palantir.gradle.consistentversions:gradle-consistent-versions'
+    gradlePluginForTesting 'com.palantir.gradle.consistentversions:gradle-consistent-versions'
 }
 
 gradlePlugin {

--- a/gradle-plugin-testing/build.gradle
+++ b/gradle-plugin-testing/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     testRuntimeOnly 'com.google.guava:guava'
     gradlePluginForTesting 'com.palantir.gradle.consistentversions:gradle-consistent-versions'
+
+    // This needs to remain until all nebula based tests are removed from this project
     testRuntimeOnly 'com.palantir.gradle.consistentversions:gradle-consistent-versions'
 }
 

--- a/gradle-plugin-testing/build.gradle
+++ b/gradle-plugin-testing/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     testRuntimeOnly 'com.google.guava:guava'
     gradlePluginForTesting 'com.palantir.gradle.consistentversions:gradle-consistent-versions'
+    testRuntimeOnly 'com.palantir.gradle.consistentversions:gradle-consistent-versions'
 }
 
 gradlePlugin {

--- a/gradle-plugin-testing/build.gradle
+++ b/gradle-plugin-testing/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation 'com.palantir.baseline:gradle-baseline-java'
     implementation 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone'
 
+    compileOnly 'com.palantir.gradle.consistentversions:gradle-consistent-versions'
+
     testImplementation project(':gradle-plugin-testing-junit')
     testImplementation 'com.netflix.nebula:nebula-test'
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -120,18 +120,7 @@ public class PluginTestingPlugin implements Plugin<Project> {
             });
         });
 
-        NamedDomainObjectProvider<DependencyScopeConfiguration> gradlePluginForTesting =
-                project.getConfigurations().dependencyScope("gradlePluginForTesting");
-
-        NamedDomainObjectProvider<ResolvableConfiguration> gradlePluginForTestingResolvable =
-                project.getConfigurations()
-                        .resolvable(
-                                "gradlePluginForTestingResolvable",
-                                resolvable -> resolvable.extendsFrom(gradlePluginForTesting.get()));
-
-        project.getTasks().named("pluginUnderTestMetadata", PluginUnderTestMetadata.class, pluginUnderTestMetadata -> {
-            pluginUnderTestMetadata.getPluginClasspath().from(gradlePluginForTestingResolvable);
-        });
+        addGradlePluginForTestingConfigurations(project);
     }
 
     private static void setupErrorprones(Project project) {
@@ -180,5 +169,20 @@ public class PluginTestingPlugin implements Plugin<Project> {
                 .or(() -> Optional.ofNullable(
                         PluginTestingPlugin.class.getPackage().getImplementationVersion()))
                 .orElseThrow(() -> new RuntimeException("PluginTestingPlugin implementation version not found"));
+    }
+
+    private static void addGradlePluginForTestingConfigurations(Project project) {
+        NamedDomainObjectProvider<DependencyScopeConfiguration> gradlePluginForTesting =
+                project.getConfigurations().dependencyScope("gradlePluginForTesting");
+
+        NamedDomainObjectProvider<ResolvableConfiguration> gradlePluginForTestingResolvable =
+                project.getConfigurations()
+                        .resolvable(
+                                "gradlePluginForTestingResolvable",
+                                resolvable -> resolvable.extendsFrom(gradlePluginForTesting.get()));
+
+        project.getTasks().named("pluginUnderTestMetadata", PluginUnderTestMetadata.class, pluginUnderTestMetadata -> {
+            pluginUnderTestMetadata.getPluginClasspath().from(gradlePluginForTestingResolvable);
+        });
     }
 }

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.plugintesting;
 import com.palantir.baseline.tasks.CheckUnusedDependenciesParentTask;
 import com.palantir.gradle.plugintesting.TestDependencyVersionsTask.TestDependency;
 import com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorPronePlugin;
+import com.palantir.gradle.versions.VersionsLockExtension;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -183,6 +184,12 @@ public class PluginTestingPlugin implements Plugin<Project> {
 
         project.getTasks().named("pluginUnderTestMetadata", PluginUnderTestMetadata.class, pluginUnderTestMetadata -> {
             pluginUnderTestMetadata.getPluginClasspath().from(gradlePluginForTestingResolvable);
+        });
+
+        project.getRootProject().getPluginManager().withPlugin("com.palantir.consistent-versions", _plugin -> {
+            project.getExtensions()
+                    .getByType(VersionsLockExtension.class)
+                    .test(scope -> scope.from(gradlePluginForTestingResolvable.getName()));
         });
     }
 }

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -27,12 +27,15 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.DependencyScopeConfiguration;
+import org.gradle.api.artifacts.ResolvableConfiguration;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin;
+import org.gradle.plugin.devel.tasks.PluginUnderTestMetadata;
 
 public class PluginTestingPlugin implements Plugin<Project> {
     /**
@@ -115,6 +118,19 @@ public class PluginTestingPlugin implements Plugin<Project> {
                     }
                 }
             });
+        });
+
+        NamedDomainObjectProvider<DependencyScopeConfiguration> gradlePluginForTesting =
+                project.getConfigurations().dependencyScope("gradlePluginForTesting");
+
+        NamedDomainObjectProvider<ResolvableConfiguration> gradlePluginForTestingResolvable =
+                project.getConfigurations()
+                        .resolvable(
+                                "gradlePluginForTestingResolvable",
+                                resolvable -> resolvable.extendsFrom(gradlePluginForTesting.get()));
+
+        project.getTasks().named("pluginUnderTestMetadata", PluginUnderTestMetadata.class, pluginUnderTestMetadata -> {
+            pluginUnderTestMetadata.getPluginClasspath().from(gradlePluginForTestingResolvable);
         });
     }
 

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.plugintesting;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ class PluginTestingJunitPluginTest {
             plugins {
                 id 'com.palantir.gradle-plugin-testing'
                 id 'java-gradle-plugin'
+                id 'com.palantir.consistent-versions' version '3.6.0'
             }
 
             repositories {
@@ -56,6 +58,50 @@ class PluginTestingJunitPluginTest {
                 gradleVersions = ['7.6.5', '8.14.3']
             }
             """);
+
+        rootProject.file("versions.lock").createEmpty();
+    }
+
+    @Test
+    void can_add_external_gradle_plugins_for_testing(GradleInvoker gradleInvoker, RootProject rootProject) {
+
+        rootProject.buildGradle().append("""
+            dependencies {
+                gradlePluginForTesting 'com.palantir.sls-packaging:gradle-sls-packaging'
+            }
+            """);
+
+        rootProject.propertiesFile("versions.props").appendProperty("com.palantir.sls-packaging:*", "7.84.0");
+
+        rootProject.testSourceSet().java().writeClass("""
+            package test;
+
+            import com.palantir.gradle.testing.execution.GradleInvoker;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.project.RootProject;
+            import org.junit.jupiter.api.Test;
+
+            @GradlePluginTests
+            class TestClass {
+                @Test
+                void testMethod(GradleInvoker gradle, RootProject rootProject) {
+
+                    rootProject.buildGradle().prepend(\"""
+                        plugins {
+                            id 'com.palantir.sls-asset-distribution'
+                        }
+
+                        def pluginVersion = plugins.getPlugin('com.palantir.sls-asset-distribution').getClass().package.implementationVersion
+                        println "plugin version: $pluginVersion"
+                        ""\");
+
+                    gradle.withArgs().buildsSuccessfully();
+                }
+            }
+            """);
+
+        InvocationResult result = gradleInvoker.withArgs("test").buildsSuccessfully();
+        result.assertThat().output().contains("pluginVersion: 7.84.0");
     }
 
     @Test

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -19,7 +19,6 @@ package com.palantir.gradle.plugintesting;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
-import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,13 +94,12 @@ class PluginTestingJunitPluginTest {
                         println "plugin version: $pluginVersion"
                         ""\");
 
-                    gradle.withArgs().buildsSuccessfully();
+                    gradle.withArgs().buildsSuccessfully().assertThat().output().contains("plugin version: 7.84.0");
                 }
             }
             """);
 
-        InvocationResult result = gradleInvoker.withArgs("test").buildsSuccessfully();
-        result.assertThat().output().contains("pluginVersion: 7.84.0");
+        gradleInvoker.withArgs("test").buildsSuccessfully();
     }
 
     @Test

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -103,6 +103,25 @@ class PluginTestingJunitPluginTest {
     }
 
     @Test
+    void confirm_gradlePluginForTesting_is_locked(GradleInvoker gradleInvoker, RootProject rootProject) {
+
+        rootProject.buildGradle().append("""
+            dependencies {
+                gradlePluginForTesting 'com.palantir.sls-packaging:gradle-sls-packaging'
+            }
+            """);
+
+        rootProject.propertiesFile("versions.props").appendProperty("com.palantir.sls-packaging:*", "7.84.0");
+
+        gradleInvoker.withArgs("writeVersionsLock").buildsSuccessfully();
+        rootProject
+                .file("versions.lock")
+                .assertThat()
+                .content()
+                .containsSubsequence("[Test dependencies]", "com.palantir.sls-packaging:gradle-sls-packaging = 7.84.0");
+    }
+
+    @Test
     void correct_versions_from_extension_are_used_by_junit_library(
             GradleInvoker gradleInvoker, RootProject rootProject) {
 

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -36,7 +36,7 @@ class PluginTestingJunitPluginTest {
             plugins {
                 id 'com.palantir.gradle-plugin-testing'
                 id 'java-gradle-plugin'
-                id 'com.palantir.consistent-versions' version '3.6.0'
+                id 'com.palantir.consistent-versions'
             }
 
             repositories {
@@ -118,7 +118,7 @@ class PluginTestingJunitPluginTest {
                 .file("versions.lock")
                 .assertThat()
                 .content()
-                .containsSubsequence("[Test dependencies]", "com.palantir.sls-packaging:gradle-sls-packaging = 7.84.0");
+                .containsSubsequence("[Test dependencies]", "com.palantir.sls-packaging:gradle-sls-packaging:7.84.0");
     }
 
     @Test

--- a/versions.lock
+++ b/versions.lock
@@ -16,6 +16,18 @@ com.diffplug.spotless:spotless-lib-extra:2.25.3 (1 constraints: 4c132341)
 
 com.diffplug.spotless:spotless-plugin-gradle:6.6.0 (1 constraints: c51120f5)
 
+com.fasterxml.jackson.core:jackson-annotations:2.20 (4 constraints: 444484b1)
+
+com.fasterxml.jackson.core:jackson-core:2.20.0 (3 constraints: 8740c06e)
+
+com.fasterxml.jackson.core:jackson-databind:2.20.0 (2 constraints: 042e890b)
+
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.20.0 (1 constraints: f01b1e62)
+
+com.fasterxml.jackson.datatype:jackson-datatype-guava:2.20.0 (1 constraints: f01b1e62)
+
+com.fasterxml.woodstox:woodstox-core:7.1.1 (1 constraints: 3d174926)
+
 com.github.ben-manes.caffeine:caffeine:3.1.8 (2 constraints: a724eed3)
 
 com.github.kevinstern:software-and-algorithms:1.0 (1 constraints: 7e12fcf5)
@@ -50,9 +62,17 @@ com.googlecode.java-diff-utils:diffutils:1.3.0 (1 constraints: bd11fef4)
 
 com.googlecode.javaewah:JavaEWAH:1.1.12 (1 constraints: 750eee5e)
 
+com.netflix.nebula:nebula-dependency-recommender:11.0.0 (1 constraints: e61b0462)
+
+com.netflix.nebula:nebula-gradle-interop:1.0.11 (1 constraints: 9214098d)
+
 com.netflix.nebula:nebula-test:10.6.2 (1 constraints: 3b053b3b)
 
 com.palantir.baseline:gradle-baseline-java:6.8.0 (1 constraints: 10052136)
+
+com.palantir.gradle.consistentversions:gradle-consistent-versions:2.31.0 (1 constraints: 38053a3b)
+
+com.palantir.gradle.consistentversions:gradle-consistent-versions-idea:2.31.0 (1 constraints: ea1b1262)
 
 com.palantir.gradle.failure-reports:gradle-failure-reports-exceptions:1.2.0 (2 constraints: 722d7f5b)
 
@@ -144,6 +164,8 @@ org.codehaus.plexus:plexus-sec-dispatcher:2.0 (1 constraints: 5c100b99)
 
 org.codehaus.plexus:plexus-utils:3.5.1 (11 constraints: 3fa89966)
 
+org.codehaus.woodstox:stax2-api:4.2.2 (2 constraints: 6a278bd2)
+
 org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r (2 constraints: 562b9625)
 
 org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5 (3 constraints: 852caa93)
@@ -155,6 +177,14 @@ org.hamcrest:hamcrest:2.2 (2 constraints: 43187376)
 org.hamcrest:hamcrest-core:2.2 (3 constraints: 84262b80)
 
 org.jetbrains:annotations:26.0.2 (2 constraints: 1a148373)
+
+org.jetbrains.kotlin:kotlin-stdlib:1.3.50 (2 constraints: be218de0)
+
+org.jetbrains.kotlin:kotlin-stdlib-common:1.3.50 (1 constraints: 420fc67a)
+
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50 (1 constraints: e010efd2)
+
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.50 (1 constraints: 58113be1)
 
 org.jspecify:jspecify:1.0.0 (3 constraints: 4431fdfd)
 
@@ -182,18 +212,6 @@ org.spockframework:spock-junit4:2.3-groovy-3.0 (1 constraints: 7a1000b0)
 
 [Test dependencies]
 
-com.fasterxml.jackson.core:jackson-annotations:2.20 (4 constraints: 444484b1)
-
-com.fasterxml.jackson.core:jackson-core:2.20.0 (3 constraints: 8740c06e)
-
-com.fasterxml.jackson.core:jackson-databind:2.20.0 (2 constraints: 042e890b)
-
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.20.0 (1 constraints: f01b1e62)
-
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.20.0 (1 constraints: f01b1e62)
-
-com.fasterxml.woodstox:woodstox-core:7.1.1 (1 constraints: 3d174926)
-
 com.google.auto.value:auto-value:1.10 (1 constraints: e711f8e8)
 
 com.google.errorprone:error_prone_test_helpers:2.42.0 (1 constraints: 3a05413b)
@@ -206,25 +224,7 @@ com.google.testing.compile:compile-testing:0.21.0 (1 constraints: 89149575)
 
 com.google.truth:truth:1.4.0 (2 constraints: 72265a6a)
 
-com.netflix.nebula:nebula-dependency-recommender:11.0.0 (1 constraints: e61b0462)
-
-com.netflix.nebula:nebula-gradle-interop:1.0.11 (1 constraints: 9214098d)
-
-com.palantir.gradle.consistentversions:gradle-consistent-versions:2.31.0 (1 constraints: 38053a3b)
-
-com.palantir.gradle.consistentversions:gradle-consistent-versions-idea:2.31.0 (1 constraints: ea1b1262)
-
-org.codehaus.woodstox:stax2-api:4.2.2 (2 constraints: 6a278bd2)
-
 org.hamcrest:hamcrest-library:2.2 (1 constraints: fc138e38)
-
-org.jetbrains.kotlin:kotlin-stdlib:1.3.50 (2 constraints: be218de0)
-
-org.jetbrains.kotlin:kotlin-stdlib-common:1.3.50 (1 constraints: 420fc67a)
-
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50 (1 constraints: e010efd2)
-
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.50 (1 constraints: 58113be1)
 
 org.junit.jupiter:junit-jupiter:5.13.4 (1 constraints: 7e074077)
 


### PR DESCRIPTION
## Before this PR
The Nebula framework makes an `init.gradle` script which added everything from the containing project's `testRuntimeClasspath` to build script dependencies of the test.  This allowed tests to apply plugins.

The new junit-based framework does not do this - it uses Gradle's supplied TestKit framework, which has a `withPluginClasspath` method we use. This does not use an init script but instead writes out a `plugin-under-test-metadata.properties` at build time then uses it in the tests for the `plugins {}`  block classpath. It uses the `runtimeClasspath` rather than the `testRuntimeClasspath`. This causes tests which are converted from nebula to fail with errors like this:

```
* Exception is:
org.gradle.api.plugins.UnknownPluginException: Plugin [id: ‘com.palantir.jdks.latest’] was not found in any of the following sources:
- Gradle Core Plugins (plugin is not in ‘org.gradle’ namespace)
- Gradle TestKit (classpath: /home/circleci/...)
- Included Builds (No included builds contain this plugin)
- Plugin Repositories (plugin dependency must include a version number for this source)
```

...because we were including the dependencies for the gradle plugins using `testRuntimeOnly`, and test kit only looks at the `runtimeClasspath` rather than `testRuntimeClasspath`.

## After this PR
==COMMIT_MSG==
There is now a `gradlePluginsForTesting` configuration that allows external Gradle plugin dependencies to be used within Gradle plugin tests within the `plugins {}` block.
==COMMIT_MSG==

We augment the `plugin-under-test-metadata.properties` file with these extra jars to allow using external plugins in `plugins {}` blocks in tests.

They are now not included as `testRuntimeOnly`, which is good because they are not actually used in the actualy junit tests - they are used within Gradle invocations from tests.

This `gradlePluginForTesting` configuration is locked which makes it safe the augment the the `plugin-under-test-metadata.properties` file as any dependencies shared with `runtimeClasspath` will have the same versions.

## Possible downsides?
* Locking the `gradlePluginForTesting` configuration means we get constraints from gradle plugins we test against, which may be suprising. eg this repo has Jackson 2.18. We test with sls-packaging, which has Jackson 2.20. Since we test with Jackson 2.20 we use 2.20 in the lockfile.
* Had to bootstrap this feature, will remove after releasing.

