### PR TITLE
Remove `gradlePluginForTesting` bootstrapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.69.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.24.0'
-        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.24.0'
+        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.25.0'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.26.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.81.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.24.0'

--- a/gradle-plugin-testing/build.gradle
+++ b/gradle-plugin-testing/build.gradle
@@ -4,15 +4,6 @@ apply plugin: 'com.palantir.external-publish-jar'
 apply plugin: 'com.palantir.gradle-plugin-testing'
 apply plugin: 'com.palantir.external-publish-gradle-plugin'
 
-// used for self bootstrapping - remove on next release and bump own version
-configurations {
-    gradlePluginForTesting
-}
-
-tasks.named("pluginUnderTestMetadata", PluginUnderTestMetadata) {
-    it.getPluginClasspath().from(configurations.named("gradlePluginForTesting"))
-}
-
 dependencies {
     implementation project(':plugin-testing-core')
     implementation 'com.palantir.baseline:gradle-baseline-java'


### PR DESCRIPTION
## Before this PR
We needed to add some bootstrapping to get #262 working.

## After this PR
It's deleted.

## Possible downsides?
Circle will need rerunning when 0.25.0 has actually finished publishing

