### PR TITLE
Fix: Errorprone patches where not being applied when running `-PerrorProneApply` 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        mavenLocal()
     }
 
     dependencies {
@@ -9,7 +10,7 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.69.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.24.0'
-        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.19.0'
+        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:999'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.26.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.81.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.24.0'
@@ -46,6 +47,7 @@ allprojects {
     repositories {
         mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
         gradlePluginPortal()
+        mavenLocal()
     }
 
     group 'com.palantir.gradle.plugintesting'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-        mavenLocal()
     }
 
     dependencies {
@@ -10,7 +9,7 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.69.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.24.0'
-        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:999'
+        classpath 'com.palantir.gradle.plugintesting:gradle-plugin-testing:0.25.0'
         classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.26.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.81.0'
         classpath 'com.palantir.suppressible-error-prone:gradle-suppressible-error-prone:2.24.0'
@@ -47,7 +46,6 @@ allprojects {
     repositories {
         mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
         gradlePluginPortal()
-        mavenLocal()
     }
 
     group 'com.palantir.gradle.plugintesting'

--- a/gradle-plugin-testing-error-prone/src/test/java/com/palantir/gradle/testing/errorprone/GradleTestStringFormattingTest.java
+++ b/gradle-plugin-testing-error-prone/src/test/java/com/palantir/gradle/testing/errorprone/GradleTestStringFormattingTest.java
@@ -270,6 +270,67 @@ class GradleTestStringFormattingTest {
             """);
     }
 
+    @Test
+    void autofix_formatted_multiline_strings_in_project_file() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.ProjectFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(ProjectFile file) {
+                    file.append(""\"
+                        foo %s
+                    ""\".formatted(3));
+
+                    file.appendLine(""\"
+                        foo %s bar %d
+                    ""\".formatted("hello", 42));
+
+                    file.prepend(String.format(""\"
+                        foo %s bar %d
+                    ""\", "hello", 42));
+
+                    file.prependLine(""\"
+                        test %s
+                    ""\".formatted("value"));
+
+                    file.overwrite(""\"
+                        content %s
+                    ""\".formatted("data"));
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.ProjectFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(ProjectFile file) {
+                    file.append(""\"
+                        foo %s
+                    ""\", 3);
+
+                    file.appendLine(""\"
+                        foo %s bar %d
+                    ""\", "hello", 42);
+
+                    file.prepend(""\"
+                        foo %s bar %d
+                    ""\", "hello", 42);
+
+                    file.prependLine(""\"
+                        test %s
+                    ""\", "value");
+
+                    file.overwrite(""\"
+                        content %s
+                    ""\", "data");
+                }
+            }
+            """);
+    }
+
     private void test(@Language("Java") String javaCode) {
         CompilationTestHelper compilationTestHelper =
                 CompilationTestHelper.newInstance(GradleTestStringFormatting.class, getClass());

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectFileFormattingUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectFileFormattingUsageTest.java
@@ -42,7 +42,7 @@ class ProjectFileFormattingUsageTest {
             tasks.register('%s') {
                 doLast {}
             }
-            """.formatted("myTask"));
+            """, "myTask");
 
         assertThat(rootProject.buildGradle().text()).contains("tasks.register('myTask')");
     }
@@ -68,7 +68,7 @@ class ProjectFileFormattingUsageTest {
             tasks.register('%s') {
                 doLast {}
             }
-            """.formatted("myTask"));
+            """, "myTask");
 
         assertThat(rootProject.buildGradle().text())
                 .contains("plugins { id 'java' }")
@@ -84,7 +84,7 @@ class ProjectFileFormattingUsageTest {
 
     @Test
     void can_format_appendLine_manually(RootProject rootProject) {
-        rootProject.buildGradle().appendLine("version = '%s'".formatted("1.0.0"));
+        rootProject.buildGradle().appendLine("version = '%s'", "1.0.0");
 
         assertThat(rootProject.buildGradle().text()).isEqualTo("version = '1.0.0'\n");
     }
@@ -108,7 +108,7 @@ class ProjectFileFormattingUsageTest {
             tasks.register('%s') {
                 doLast {}
             }
-            """.formatted("myTask"));
+            """, "myTask");
 
         assertThat(rootProject.buildGradle().text()).startsWith("tasks.register('myTask')");
     }
@@ -124,7 +124,7 @@ class ProjectFileFormattingUsageTest {
     @Test
     void can_format_prependLine_manually(RootProject rootProject) {
         rootProject.buildGradle().overwrite("task foo {}");
-        rootProject.buildGradle().prependLine("version = '%s'".formatted("1.0.0"));
+        rootProject.buildGradle().prependLine("version = '%s'", "1.0.0");
 
         assertThat(rootProject.buildGradle().text()).startsWith("version = '1.0.0'\n");
     }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectFileFormattingUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectFileFormattingUsageTest.java
@@ -37,32 +37,7 @@ class ProjectFileFormattingUsageTest {
     }
 
     @Test
-    void can_format_override_manually(RootProject rootProject) {
-        rootProject.buildGradle().overwrite("""
-            tasks.register('%s') {
-                doLast {}
-            }
-            """, "myTask");
-
-        assertThat(rootProject.buildGradle().text()).contains("tasks.register('myTask')");
-    }
-
-    @Test
     void can_format_append(RootProject rootProject) {
-        rootProject.buildGradle().overwrite("plugins { id 'java' }\n");
-        rootProject.buildGradle().append("""
-            tasks.register('%s') {
-                doLast {}
-            }
-            """, "myTask");
-
-        assertThat(rootProject.buildGradle().text())
-                .contains("plugins { id 'java' }")
-                .contains("tasks.register('myTask')");
-    }
-
-    @Test
-    void can_format_append_manually(RootProject rootProject) {
         rootProject.buildGradle().overwrite("plugins { id 'java' }\n");
         rootProject.buildGradle().append("""
             tasks.register('%s') {
@@ -83,13 +58,6 @@ class ProjectFileFormattingUsageTest {
     }
 
     @Test
-    void can_format_appendLine_manually(RootProject rootProject) {
-        rootProject.buildGradle().appendLine("version = '%s'", "1.0.0");
-
-        assertThat(rootProject.buildGradle().text()).isEqualTo("version = '1.0.0'\n");
-    }
-
-    @Test
     void can_format_prepend(RootProject rootProject) {
         rootProject.buildGradle().overwrite("task foo {}\n");
         rootProject.buildGradle().prepend("""
@@ -102,27 +70,7 @@ class ProjectFileFormattingUsageTest {
     }
 
     @Test
-    void can_format_prepend_manually(RootProject rootProject) {
-        rootProject.buildGradle().overwrite("task foo {}\n");
-        rootProject.buildGradle().prepend("""
-            tasks.register('%s') {
-                doLast {}
-            }
-            """, "myTask");
-
-        assertThat(rootProject.buildGradle().text()).startsWith("tasks.register('myTask')");
-    }
-
-    @Test
     void can_format_prependLine(RootProject rootProject) {
-        rootProject.buildGradle().overwrite("task foo {}");
-        rootProject.buildGradle().prependLine("version = '%s'", "1.0.0");
-
-        assertThat(rootProject.buildGradle().text()).startsWith("version = '1.0.0'\n");
-    }
-
-    @Test
-    void can_format_prependLine_manually(RootProject rootProject) {
         rootProject.buildGradle().overwrite("task foo {}");
         rootProject.buildGradle().prependLine("version = '%s'", "1.0.0");
 

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -17,9 +17,11 @@ package com.palantir.gradle.plugintesting;
 
 import com.palantir.baseline.tasks.CheckUnusedDependenciesParentTask;
 import com.palantir.gradle.plugintesting.TestDependencyVersionsTask.TestDependency;
+import com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorProneExtension;
 import com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorPronePlugin;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectProvider;
@@ -42,6 +44,8 @@ public class PluginTestingPlugin implements Plugin<Project> {
 
     static final List<String> CORE_MAVEN_NAMES =
             List.of("plugin-testing-core", "configuration-cache-spec", "gradle-plugin-testing-junit");
+
+    public static final Set<String> PATCHABLE_CHECKS = Set.of("GradleTestStringFormatting");
 
     private static final String MAVEN_GROUP = "com.palantir.gradle.plugintesting";
 
@@ -126,6 +130,11 @@ public class PluginTestingPlugin implements Plugin<Project> {
                     + jarImplementationVersionOrTestVersion(project);
 
             project.getDependencies().add("errorprone", errorProneJarCoordinate);
+
+            project.getExtensions()
+                    .getByType(SuppressibleErrorProneExtension.class)
+                    .getPatchChecks()
+                    .addAll(PATCHABLE_CHECKS);
         });
     }
 


### PR DESCRIPTION
## Before this PR
Could only trigger the errorprone patches via ` -PerrorProneApply=<Patch name>`
## After this PR
set the suppresible errorpone extension to apply the patches from these errorprones automatically similar to https://github.com/palantir/gradle-guide/blob/814abed80a5a0ae613210db10b4c1e66b861fe4a/gradle-guide/src/main/java/com/palantir/gradle/guide/GradleGuidePlugin.java#L71
 
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Our errorpone patchs should work when running `-PerrorProneApply` 
==COMMIT_MSG==

## Possible downsides?
Need to maintain a manual list but this is similar to our other usages
<!-- Please describe any way users could be negatively affected by this PR. -->

