### PR TITLE
Ensure IntelliJ "Run test with coverage" works

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
@@ -40,23 +40,35 @@ public final class GradleInvoker {
                 .add("--stacktrace")
                 .build()
                 .toArray(String[]::new);
+
         return new GradleInvocation(GradleRunner.create()
                 .withProjectDir(rootProjectDir.toFile())
-                .withDebug(isJavaDebugAgentLoaded())
+                .withDebug(shouldRunInTestkitDebugMode())
                 .forwardOutput()
                 .withGradleVersion(gradleVersion.version())
                 .withPluginClasspath()
                 .withArguments(argsWithStacktrace));
     }
 
+    private static boolean shouldRunInTestkitDebugMode() {
+        // `withDebug(true)` will run the Gradle daemon inside the same JVM as the test, whereas
+        // `withDebug(false)` will run Gradle in a new daemon.
+        // When running tests from IntelliJ with debug or coverage, they only work when the Gradle daemon
+        // is in the same the JVM as the test, so we must set `withDebug(true)` in these cases.
+        // Beware: There can be differences between these two modes!
+        return isJavaDebugAgentLoaded() || isRunningCoverageInIntelliJ();
+    }
+
     private static boolean isJavaDebugAgentLoaded() {
         // When you run a test with debug in intellij, it passes an arg to the test process like:
         //   -agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=127.0.0.1:54342
-        // We can use this to detect whether we should run with Gradle tooling `.withDebug` or not,
-        // `withDebug(true)` will run the Gradle tooling inside the same JVM as the test, meaning
-        // debugging works, whereas `withDebug(false)` will run Gradle in a new daemon. There can be
-        // differences between these two modes!
         return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
-                .anyMatch(s -> s.contains("-agentlib:jdwp"));
+                .anyMatch(arg -> arg.contains("-agentlib:jdwp"));
+    }
+
+    private static boolean isRunningCoverageInIntelliJ() {
+        // When you run a test with coverage in intellij, it sets a system property on the test JVM
+        // by adding the jvm arg `-Didea.coverage.calculate.hits=true`.
+        return Boolean.getBoolean("idea.coverage.calculate.hits");
     }
 }


### PR DESCRIPTION
## Before this PR
Currently, "Run with coverage" in IntelliJ does not work, because the testing framework will always fork the JVM unless debugging is enabled, and IntelliJ runs coverage without debug. It makes it look like there is no coverage:

<img width="782" height="244" alt="Screenshot 2025-11-07 at 12 55 50" src="https://github.com/user-attachments/assets/273ca121-9723-475d-a715-69a3bd7c4ead" />


## After this PR
==COMMIT_MSG==
Ensure IntelliJ "Run test with coverage" works with new Java/JUnit Gradle plugin testing framework
==COMMIT_MSG==

We detect whether coverage is enabled and tell testkit to fork the JVM, like we currently do for debugging.

It now works:

<img width="785" height="240" alt="Screenshot 2025-11-07 at 12 57 31" src="https://github.com/user-attachments/assets/ef459a8f-2939-4532-afdf-e4d5309f7302" />


## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

