### PR TITLE
Remove `GradleInvoker#withEnvironment`

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvocation.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.testing.execution;
 
-import java.util.Map;
 import org.gradle.testkit.runner.GradleRunner;
 
 public final class GradleInvocation {
@@ -24,11 +23,6 @@ public final class GradleInvocation {
 
     GradleInvocation(GradleRunner gradleRunner) {
         this.gradleRunner = gradleRunner;
-    }
-
-    public GradleInvocation withEnvironment(Map<String, String> environment) {
-        gradleRunner.withEnvironment(environment);
-        return this;
     }
 
     public InvocationResult buildsSuccessfully() {


### PR DESCRIPTION
## Before this PR
We expose a method `withEnvironment` in `GradleInvoker` - it delegates to TestKit's `GradleRunner#withEnvironment`.

This is highly dangerous as `withEnvironment` [does not work unless the Gradle invocation process is forked](https://github.com/gradle/gradle/blob/bcc7647dcec3e0c24a69afdb88bbeecc999cdfcb/platforms/extensibility/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java#L327-L331):

```java
if (environment != null && debug) {
    throw new InvalidRunnerConfigurationException("Debug mode is not allowed when environment variables are specified. " +
        "Debug mode runs 'in process' but we need to fork a separate process to pass environment variables. " +
        "To run with debug mode, please remove environment variables.");
}
```

If the tests are run under debug or with coverage, they will not be forked and so fail.

Someone could write a test that passes CI but is impossible to debug (or run coverage!).

## After this PR
==COMMIT_MSG==
Remove `GradleInvoker#withEnvironment` as the current implementation does not work under debug or coverage. Consider using [`gradle-utils:environment-variables`](https://github.com/palantir/gradle-utils?tab=readme-ov-file#environmentvariables) instead.
==COMMIT_MSG==

Additionally, using the environment variables like this has the classic error (that [`gradle-utils:environment-variables`](https://github.com/palantir/gradle-utils?tab=readme-ov-file#environmentvariables) prevents) of "my code using `$CIRCLE_TAG` now behaves differently on publish" as it inherits env vars.

Maybe eventually we should have integration with [`gradle-utils:environment-variables`](https://github.com/palantir/gradle-utils?tab=readme-ov-file#environmentvariables).

## Possible downsides?
No other code is using this thankfully - we don't even have a test. Only our AI migration prompt references it.

