### PR TITLE
Add structured plugins block API - Errorprone

### DIFF
--- a/gradle-plugin-testing-error-prone/build.gradle
+++ b/gradle-plugin-testing-error-prone/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 dependencies {
     implementation 'com.google.errorprone:error_prone_check_api'
+    implementation 'one.util:streamex'
 
     annotationProcessor 'com.google.auto.service:auto-service'
     compileOnly 'com.google.auto.service:auto-service'

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
@@ -29,7 +29,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import java.util.Optional;
-import java.util.stream.StreamSupport;
+import one.util.streamex.StreamEx;
 
 public final class GradlePluginTestHelpers {
     private static final Matcher<Tree> WITHIN_GRADLE_PLUGIN_TESTS_CLASS = Matchers.enclosingNode(Matchers.allOf(
@@ -52,9 +52,8 @@ public final class GradlePluginTestHelpers {
 
     static Optional<ExpressionTree> findVariableInitializer(Symbol.VarSymbol var, VisitorState state) {
         return Optional.ofNullable(ASTHelpers.findEnclosingNode(state.getPath(), MethodTree.class))
-                .flatMap(m -> m.getBody().getStatements().stream()
-                        .filter(VariableTree.class::isInstance)
-                        .map(VariableTree.class::cast)
+                .flatMap(m -> StreamEx.of(m.getBody().getStatements())
+                        .select(VariableTree.class)
                         .filter(v -> var.equals(ASTHelpers.getSymbol(v)))
                         .collect(MoreCollectors.toOptional())
                         .map(VariableTree::getInitializer));
@@ -78,9 +77,8 @@ public final class GradlePluginTestHelpers {
         String methodName = methodSymbol.getSimpleName().toString();
         Symbol.ClassSymbol classSymbol = methodSymbol.enclClass();
 
-        return StreamSupport.stream(classSymbol.members().getSymbols().spliterator(), false)
-                .filter(Symbol.MethodSymbol.class::isInstance)
-                .map(Symbol.MethodSymbol.class::cast)
+        return StreamEx.of(classSymbol.members().getSymbols().spliterator())
+                .select(Symbol.MethodSymbol.class)
                 .filter(method -> method.getSimpleName().toString().equals(methodName))
                 .filter(method ->
                         ASTHelpers.hasAnnotation(method, "com.google.errorprone.annotations.FormatMethod", state))

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
@@ -27,7 +27,10 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import java.util.Optional;
 import one.util.streamex.StreamEx;
 
@@ -51,12 +54,14 @@ public final class GradlePluginTestHelpers {
     }
 
     static Optional<ExpressionTree> findVariableInitializer(Symbol.VarSymbol var, VisitorState state) {
-        return Optional.ofNullable(ASTHelpers.findEnclosingNode(state.getPath(), MethodTree.class))
-                .flatMap(m -> StreamEx.of(m.getBody().getStatements())
-                        .select(VariableTree.class)
-                        .filter(v -> var.equals(ASTHelpers.getSymbol(v)))
-                        .collect(MoreCollectors.toOptional())
-                        .map(VariableTree::getInitializer));
+        JavacProcessingEnvironment javacEnv = JavacProcessingEnvironment.instance(state.context);
+        return StreamEx.ofNullable(Trees.instance(javacEnv).getPath(var))
+                .filter(declPath ->
+                        declPath.getCompilationUnit() == state.getPath().getCompilationUnit())
+                .map(TreePath::getLeaf)
+                .select(VariableTree.class)
+                .map(VariableTree::getInitializer)
+                .findFirst();
     }
 
     static boolean hasFormatMethodOverload(MethodInvocationTree tree, VisitorState state) {

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
@@ -39,16 +39,16 @@ public final class GradlePluginTestHelpers {
 
     private static final String LIBRARY_PACKAGE = "com.palantir.gradle.testing.";
 
-    static boolean notWithinGradlePluginTests(Tree tree, VisitorState state) {
-        return !WITHIN_GRADLE_PLUGIN_TESTS_CLASS.matches(tree, state);
+    static boolean isWithinGradlePluginTests(Tree tree, VisitorState state) {
+        return WITHIN_GRADLE_PLUGIN_TESTS_CLASS.matches(tree, state);
     }
 
-    static boolean notGradlePluginTestsLibraryMethod(MethodInvocationTree tree) {
+    static boolean isGradlePluginTestsLibraryMethod(MethodInvocationTree tree) {
         return Optional.ofNullable(ASTHelpers.getSymbol(tree))
                 .map(Symbol.MethodSymbol::enclClass)
                 .map(classSymbol -> classSymbol.getQualifiedName().toString())
                 .filter(className -> className.startsWith(LIBRARY_PACKAGE))
-                .isEmpty();
+                .isPresent();
     }
 
     static Optional<ExpressionTree> findVariableInitializer(Symbol.VarSymbol var, VisitorState state) {

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
@@ -21,10 +21,14 @@ import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 public final class GradlePluginTestHelpers {
     private static final Matcher<Tree> WITHIN_GRADLE_PLUGIN_TESTS_CLASS = Matchers.enclosingNode(Matchers.allOf(
@@ -37,12 +41,55 @@ public final class GradlePluginTestHelpers {
         return !WITHIN_GRADLE_PLUGIN_TESTS_CLASS.matches(tree, state);
     }
 
-    static boolean isGradlePluginTestsLibraryMethod(MethodInvocationTree tree, VisitorState state) {
+    static boolean notGradlePluginTestsLibraryMethod(MethodInvocationTree tree) {
         return Optional.ofNullable(ASTHelpers.getSymbol(tree))
                 .map(Symbol.MethodSymbol::enclClass)
                 .map(classSymbol -> classSymbol.getQualifiedName().toString())
                 .filter(className -> className.startsWith(LIBRARY_PACKAGE))
+                .isEmpty();
+    }
+
+    static Optional<ExpressionTree> findVariableInitializer(Symbol.VarSymbol var, VisitorState state) {
+        return Optional.ofNullable(ASTHelpers.findEnclosingNode(state.getPath(), MethodTree.class))
+                .flatMap(m -> m.getBody().getStatements().stream()
+                        .filter(VariableTree.class::isInstance)
+                        .map(VariableTree.class::cast)
+                        .filter(v -> var.equals(ASTHelpers.getSymbol(v)))
+                        .findFirst()
+                        .map(VariableTree::getInitializer));
+    }
+
+    static boolean hasFormatMethodOverload(MethodInvocationTree tree, VisitorState state) {
+        return Optional.ofNullable(ASTHelpers.getSymbol(tree))
+                .map(methodSymbol -> hasFormatOverloadInClass(methodSymbol, state))
+                .orElse(false);
+    }
+
+    static boolean isFormatMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        return Optional.ofNullable(ASTHelpers.getSymbol(tree))
+                .filter(method ->
+                        ASTHelpers.hasAnnotation(method, "com.google.errorprone.annotations.FormatMethod", state))
+                .filter(method -> hasFormatStringParameter(method, state))
                 .isPresent();
+    }
+
+    private static boolean hasFormatOverloadInClass(Symbol.MethodSymbol methodSymbol, VisitorState state) {
+        String methodName = methodSymbol.getSimpleName().toString();
+        Symbol.ClassSymbol classSymbol = methodSymbol.enclClass();
+
+        return StreamSupport.stream(classSymbol.members().getSymbols().spliterator(), false)
+                .filter(Symbol.MethodSymbol.class::isInstance)
+                .map(Symbol.MethodSymbol.class::cast)
+                .filter(method -> method.getSimpleName().toString().equals(methodName))
+                .filter(method ->
+                        ASTHelpers.hasAnnotation(method, "com.google.errorprone.annotations.FormatMethod", state))
+                .anyMatch(method -> hasFormatStringParameter(method, state));
+    }
+
+    private static boolean hasFormatStringParameter(Symbol.MethodSymbol method, VisitorState state) {
+        return method.getParameters().stream()
+                .anyMatch(param ->
+                        ASTHelpers.hasAnnotation(param, "com.google.errorprone.annotations.FormatString", state));
     }
 
     private GradlePluginTestHelpers() {}

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.testing.errorprone;
 
-import com.google.common.collect.MoreCollectors;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -24,7 +23,6 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.testing.errorprone;
 
+import com.google.common.collect.MoreCollectors;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
@@ -55,7 +56,7 @@ public final class GradlePluginTestHelpers {
                         .filter(VariableTree.class::isInstance)
                         .map(VariableTree.class::cast)
                         .filter(v -> var.equals(ASTHelpers.getSymbol(v)))
-                        .findFirst()
+                        .collect(MoreCollectors.toOptional())
                         .map(VariableTree::getInitializer));
     }
 

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
@@ -44,6 +44,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import one.util.streamex.StreamEx;
 
 @AutoService(BugChecker.class)
 @BugPattern(severity = SeverityLevel.ERROR, summary = """
@@ -195,10 +196,9 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
         }
         // Check if something is being chained off of this call - walk up tree looking for a content MethodInvocation
         // using us
-        return Stream.iterate(state.getPath().getParentPath(), Objects::nonNull, TreePath::getParentPath)
+        return StreamEx.iterate(state.getPath().getParentPath(), Objects::nonNull, TreePath::getParentPath)
                 .map(TreePath::getLeaf)
-                .filter(MethodInvocationTree.class::isInstance)
-                .map(MethodInvocationTree.class::cast)
+                .select(MethodInvocationTree.class)
                 .filter(parentMethod -> ASTHelpers.getReceiver(parentMethod) == tree)
                 .anyMatch(parentMethod -> isMethodWhichCouldAddPluginsManually(parentMethod, state));
     }
@@ -228,12 +228,10 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
 
         // For block lambda: text -> { return text + "string"; }
         if (lambda.getBody() instanceof BlockTree block) {
-            return block.getStatements().stream()
-                    .filter(ReturnTree.class::isInstance)
-                    .map(ReturnTree.class::cast)
+            return StreamEx.of(block.getStatements())
+                    .select(ReturnTree.class)
                     .map(ReturnTree::getExpression)
-                    .filter(BinaryTree.class::isInstance)
-                    .map(BinaryTree.class::cast)
+                    .select(BinaryTree.class)
                     .findFirst()
                     .flatMap(GradleTestPluginsBlock::extractStringFromBinaryTree);
         }

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
@@ -1,0 +1,312 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.ReturnTree;
+import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+@AutoService(BugChecker.class)
+@BugPattern(severity = SeverityLevel.ERROR, summary = """
+    Plugins must be added using .plugins().add() method. Use gradleFile.plugins().add("plugin-id") instead.
+    """)
+public final class GradleTestPluginsBlock extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+    private static final Matcher<ExpressionTree> STRING_TYPE = Matchers.isSubtypeOf("java.lang.String");
+    private static final Matcher<ExpressionTree> FILE_EDITOR_TYPE =
+            Matchers.isSubtypeOf("com.palantir.gradle.testing.files.ProjectFile.FileEditor");
+
+    private static final Pattern SIMPLE_PLUGIN_DECLARATIONS = Pattern.compile("apply plugin:\\s*['\"]([^'\"]+)['\"]"
+            + "|plugins\\.apply\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)"
+            + "|pluginManagement\\.apply\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)");
+    private static final Pattern PLUGINS_BLOCK_ID =
+            Pattern.compile("id\\s+['\"]([^'\"]+)['\"](?:\\s+apply\\s+(false|true))?");
+    private static final Pattern PLUGINS_BLOCK = Pattern.compile("plugins\\s*\\{([^}]*)\\}", Pattern.DOTALL);
+    private static final Pattern COMMENT = Pattern.compile("//.*|(?s)/\\*.*?\\*/");
+    private static final Pattern EMPTY_PLUGINS = Pattern.compile("(?s)plugins\\s*\\{\\s*\\}");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!isContentMethod(tree, state)
+                || GradlePluginTestHelpers.notGradlePluginTestsLibraryMethod(tree)
+                || GradlePluginTestHelpers.notWithinGradlePluginTests(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        return tree.getArguments().stream()
+                .findFirst()
+                .flatMap(arg -> checkForPlugins(arg, tree, state))
+                .orElse(Description.NO_MATCH);
+    }
+
+    private static boolean isContentMethod(MethodInvocationTree tree, VisitorState state) {
+        return Optional.ofNullable(ASTHelpers.getSymbol(tree))
+                .filter(method -> !method.getParameters().isEmpty())
+                .filter(method -> tree.getArguments().stream()
+                        .findFirst()
+                        .map(firstArg ->
+                                STRING_TYPE.matches(firstArg, state) || FILE_EDITOR_TYPE.matches(firstArg, state))
+                        .orElse(false))
+                .filter(method -> isProjectFileSubtype(method.enclClass(), state))
+                .isPresent();
+    }
+
+    private static boolean isProjectFileSubtype(Symbol.ClassSymbol classSymbol, VisitorState state) {
+        Type classType = classSymbol.type;
+        Type projectFileType = state.getTypeFromString("com.palantir.gradle.testing.files.ProjectFile");
+        return ASTHelpers.isSubtype(classType, projectFileType, state);
+    }
+
+    private Optional<Description> checkForPlugins(ExpressionTree arg, MethodInvocationTree tree, VisitorState state) {
+        Optional<String> content =
+                getStringLiteral(arg).or(() -> resolveStringContent(arg, state)).or(() -> extractStringFromLambda(arg));
+        if (content.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<PluginInfo> plugins = extractPlugins(content.get());
+        if (plugins.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Only autofix if arg is a literal or lambda expression (not a variable reference)
+        // AND we're not calling a @FormatMethod as we might be formatting the plugins block which would get very
+        // complicated
+        // AND we're not in a method chain (can be a FLUP, although I think chaining will be very rare)
+        boolean canAutofix = (arg instanceof LiteralTree || arg instanceof LambdaExpressionTree)
+                && !GradlePluginTestHelpers.isFormatMethodInvocation(tree, state)
+                && !isInMethodChain(tree, state);
+        return Optional.of(
+                canAutofix
+                        ? buildDescription(tree)
+                                .addFix(createFix(tree, content.get(), plugins, state))
+                                .build()
+                        : buildDescription(tree).build());
+    }
+
+    private static boolean isInMethodChain(MethodInvocationTree tree, VisitorState state) {
+        // Check if this is being called on a chain of content methods (receiver is a content method invocation)
+        if (ASTHelpers.getReceiver(tree) instanceof MethodInvocationTree receiver && isContentMethod(receiver, state)) {
+            return true;
+        }
+        // Check if something is being chained off of this call - walk up tree looking for a content MethodInvocation
+        // using us
+        return Stream.iterate(state.getPath().getParentPath(), Objects::nonNull, TreePath::getParentPath)
+                .map(TreePath::getLeaf)
+                .filter(MethodInvocationTree.class::isInstance)
+                .map(MethodInvocationTree.class::cast)
+                .filter(parentMethod -> ASTHelpers.getReceiver(parentMethod) == tree)
+                .anyMatch(parentMethod -> isContentMethod(parentMethod, state));
+    }
+
+    private static Optional<String> getStringLiteral(ExpressionTree expr) {
+        return expr instanceof LiteralTree lit && lit.getValue() instanceof String s
+                ? Optional.of(s)
+                : Optional.empty();
+    }
+
+    private static Optional<String> resolveStringContent(ExpressionTree expr, VisitorState state) {
+        return ASTHelpers.getSymbol(expr) instanceof Symbol.VarSymbol var
+                ? GradlePluginTestHelpers.findVariableInitializer(var, state)
+                        .flatMap(GradleTestPluginsBlock::getStringLiteral)
+                : Optional.empty();
+    }
+
+    private static Optional<String> extractStringFromLambda(ExpressionTree expr) {
+        if (!(expr instanceof LambdaExpressionTree lambda)) {
+            return Optional.empty();
+        }
+
+        // For expression lambda: text -> text + "string"
+        if (lambda.getBody() instanceof BinaryTree binary) {
+            return extractStringFromBinaryTree(binary);
+        }
+
+        // For block lambda: text -> { return text + "string"; }
+        if (lambda.getBody() instanceof BlockTree block) {
+            return block.getStatements().stream()
+                    .filter(ReturnTree.class::isInstance)
+                    .map(ReturnTree.class::cast)
+                    .map(ReturnTree::getExpression)
+                    .filter(BinaryTree.class::isInstance)
+                    .map(BinaryTree.class::cast)
+                    .findFirst()
+                    .flatMap(GradleTestPluginsBlock::extractStringFromBinaryTree);
+        }
+
+        return Optional.empty();
+    }
+
+    private static Optional<String> extractStringFromBinaryTree(BinaryTree binary) {
+        // Recursively search for string literals in the binary tree
+        Optional<String> left = binary.getLeftOperand() instanceof LiteralTree
+                ? getStringLiteral(binary.getLeftOperand())
+                : binary.getLeftOperand() instanceof BinaryTree
+                        ? extractStringFromBinaryTree((BinaryTree) binary.getLeftOperand())
+                        : Optional.empty();
+
+        Optional<String> right = binary.getRightOperand() instanceof LiteralTree
+                ? getStringLiteral(binary.getRightOperand())
+                : binary.getRightOperand() instanceof BinaryTree
+                        ? extractStringFromBinaryTree((BinaryTree) binary.getRightOperand())
+                        : Optional.empty();
+
+        // Combine both sides
+        return left.flatMap(l -> right.map(r -> l + r)).or(() -> left).or(() -> right);
+    }
+
+    private static List<PluginInfo> extractPlugins(String content) {
+        String cleaned = COMMENT.matcher(content).replaceAll("");
+
+        Stream<PluginInfo> simple = SIMPLE_PLUGIN_DECLARATIONS
+                .matcher(cleaned)
+                .results()
+                .map(m -> {
+                    String pluginId = IntStream.rangeClosed(1, 3)
+                            .mapToObj(m::group)
+                            .filter(Objects::nonNull)
+                            .findFirst()
+                            .orElseThrow();
+                    return new PluginInfo(pluginId, Optional.empty());
+                });
+
+        Stream<PluginInfo> blocks = PLUGINS_BLOCK.matcher(cleaned).results().flatMap(block -> PLUGINS_BLOCK_ID
+                .matcher(block.group(1))
+                .results()
+                .map(i -> new PluginInfo(
+                        i.group(1), Optional.ofNullable(i.group(2)).map(Boolean::valueOf))));
+
+        return Stream.concat(simple, blocks).toList();
+    }
+
+    private static SuggestedFix createFix(
+            MethodInvocationTree tree, String original, List<PluginInfo> plugins, VisitorState state) {
+        String cleaned = removePluginDeclarations(original);
+        String receiver = getReceiver(tree, state);
+        String pluginsStmt = buildPluginsStatement(receiver, plugins, state, tree);
+
+        // If the cleaned content is empty or whitespace-only, delete the entire method call
+        if (cleaned.trim().isEmpty()) {
+            return SuggestedFix.builder()
+                    .replace(tree, "")
+                    .postfixWith(tree, pluginsStmt)
+                    .build();
+        }
+
+        String method = ASTHelpers.getSymbol(tree).getSimpleName().toString();
+        String originalArg = state.getSourceForNode(tree.getArguments().get(0));
+        String replacement = buildMethodCall(receiver, method, cleaned, originalArg, tree, state);
+
+        return SuggestedFix.builder()
+                .replace(tree, replacement)
+                .postfixWith(tree, pluginsStmt)
+                .build();
+    }
+
+    private static String removePluginDeclarations(String content) {
+        String result = Stream.of(SIMPLE_PLUGIN_DECLARATIONS, PLUGINS_BLOCK_ID)
+                .reduce(content, (acc, pattern) -> pattern.matcher(acc).replaceAll(""), (a, b) -> b);
+        return EMPTY_PLUGINS.matcher(result).replaceAll("").trim();
+    }
+
+    private static String getReceiver(MethodInvocationTree tree, VisitorState state) {
+        return Optional.ofNullable(state.getSourceForNode(tree.getMethodSelect()))
+                .map(src -> {
+                    int dot = src.lastIndexOf('.');
+                    return dot >= 0 ? src.substring(0, dot) : src;
+                })
+                .orElse("");
+    }
+
+    private static String buildMethodCall(
+            String receiver,
+            String method,
+            String cleaned,
+            String originalArg,
+            MethodInvocationTree tree,
+            VisitorState state) {
+        String content = formatContentArg(cleaned, originalArg);
+        String additionalArgs = tree.getArguments().stream()
+                .skip(1)
+                .map(state::getSourceForNode)
+                .reduce("", (acc, arg) -> acc + ", " + arg);
+
+        return receiver + "." + method + "(" + content + additionalArgs + ");";
+    }
+
+    private static String formatContentArg(String content, String originalArg) {
+        if (originalArg.contains("->")) {
+            return formatLambdaArg(content, originalArg);
+        }
+
+        if (originalArg.startsWith("\"\"\"") && !content.isEmpty()) {
+            return "\"\"\"\n%s\n\"\"\"".formatted(content);
+        }
+
+        return "\"" + content + "\"";
+    }
+
+    private static String formatLambdaArg(String content, String originalArg) {
+        int arrowIndex = originalArg.indexOf("->");
+        String lambdaParam = originalArg.substring(0, arrowIndex).trim();
+
+        // Check if it's a block lambda: text -> { ... }
+        String lambdaBody = originalArg.substring(arrowIndex + 2).trim();
+        if (lambdaBody.startsWith("{")) {
+            // Block lambda: reconstruct as text -> { return text + ""; }
+            return "%s -> { return %s + \"%s\"; }".formatted(lambdaParam, lambdaParam, content);
+        }
+
+        // Expression lambda: text -> text + ""
+        return "%s -> %s + \"%s\"".formatted(lambdaParam, lambdaParam, content);
+    }
+
+    private static String buildPluginsStatement(
+            String receiver, List<PluginInfo> plugins, VisitorState state, MethodInvocationTree tree) {
+        String calls = plugins.stream()
+                .distinct()
+                .map(p -> ".%s(\"%s\")".formatted(p.apply().orElse(true) ? "add" : "addWithoutApply", p.id()))
+                .collect(Collectors.joining());
+
+        return "\n    %s.plugins()%s".formatted(receiver, calls);
+    }
+
+    private record PluginInfo(String id, Optional<Boolean> apply) {}
+}

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
@@ -25,6 +25,7 @@ import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.suppliers.Supplier;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.BlockTree;
@@ -35,6 +36,7 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -48,11 +50,12 @@ import java.util.stream.Stream;
     Plugins must be added using .plugins().add() method. Use gradleFile.plugins().add("plugin-id") instead.
     """)
 public final class GradleTestPluginsBlock extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
-    private static final Matcher<ExpressionTree> STRING_TYPE = Matchers.isSubtypeOf("java.lang.String");
-    private static final Matcher<ExpressionTree> FILE_EDITOR_TYPE =
-            Matchers.isSubtypeOf("com.palantir.gradle.testing.files.ProjectFile.FileEditor");
     private static final Matcher<ExpressionTree> GRADLE_FILE_TYPE =
             Matchers.isSubtypeOf("com.palantir.gradle.testing.files.gradle.GradleFile");
+    private static final Supplier<Type> JAVA_LANG_STRING =
+            VisitorState.memoize(state -> state.getTypeFromString("java.lang.String"));
+    private static final Supplier<Type> FILE_EDITOR_TYPE = VisitorState.memoize(
+            state -> state.getTypeFromString("com.palantir.gradle.testing.files.ProjectFile$FileEditor"));
 
     // Matches three forms of plugin declarations:
     // 1. apply plugin: "plugin-id"
@@ -141,17 +144,20 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
     }
 
     private static boolean isMethodWhichCouldAddPluginsManually(MethodInvocationTree tree, VisitorState state) {
-        return Optional.ofNullable(ASTHelpers.getSymbol(tree))
-                .filter(method -> !method.getParameters().isEmpty())
-                .filter(method -> tree.getArguments().stream()
-                        .findFirst()
-                        .map(firstArg ->
-                                STRING_TYPE.matches(firstArg, state) || FILE_EDITOR_TYPE.matches(firstArg, state))
-                        .orElse(false))
-                .filter(method -> Optional.ofNullable(ASTHelpers.getReceiver(tree))
-                        .map(receiver -> GRADLE_FILE_TYPE.matches(receiver, state))
-                        .orElse(false))
-                .isPresent();
+        Symbol.MethodSymbol method = ASTHelpers.getSymbol(tree);
+        if (method.getParameters().isEmpty()) {
+            return false;
+        }
+
+        Type firstParamType = method.getParameters().get(0).type;
+        if (!ASTHelpers.isSubtype(firstParamType, JAVA_LANG_STRING.get(state), state)
+                && !ASTHelpers.isSubtype(firstParamType, FILE_EDITOR_TYPE.get(state), state)) {
+            return false;
+        }
+
+        return Optional.ofNullable(ASTHelpers.getReceiver(tree))
+                .map(receiver -> GRADLE_FILE_TYPE.matches(receiver, state))
+                .orElse(false);
     }
 
     private Optional<Description> checkForPlugins(ExpressionTree arg, MethodInvocationTree tree, VisitorState state) {

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
@@ -133,8 +133,8 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
         if (!isMethodWhichCouldAddPluginsManually(tree, state)
-                || GradlePluginTestHelpers.notGradlePluginTestsLibraryMethod(tree)
-                || GradlePluginTestHelpers.notWithinGradlePluginTests(tree, state)) {
+                || !GradlePluginTestHelpers.isGradlePluginTestsLibraryMethod(tree)
+                || !GradlePluginTestHelpers.isWithinGradlePluginTests(tree, state)) {
             return Description.NO_MATCH;
         }
 

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
@@ -144,6 +144,10 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
                 .orElse(Description.NO_MATCH);
     }
 
+    /// We want to try and catch all methods on `GradleFile` that might edit the file and thus might change the plugins
+    /// block. Rather than just looking at a strict list we look at any method that takes a `String` or `FileEditor`
+    // as
+    /// the first parameter and is called on a `GradleFile` instance.
     private static boolean isMethodWhichCouldAddPluginsManually(MethodInvocationTree tree, VisitorState state) {
         Symbol.MethodSymbol method = ASTHelpers.getSymbol(tree);
         if (method.getParameters().isEmpty()) {

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
@@ -60,70 +60,70 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
     // 3. pluginManagement.apply("plugin-id")
     // Captures the plugin ID in one of three groups depending on which form matched
     private static final Pattern SIMPLE_PLUGIN_DECLARATIONS = Pattern.compile(
-            "apply plugin:"          // literal "apply plugin:"
-                    + "\\s*"         // optional whitespace
-                    + "['\"]"        // opening quote (single or double)
-                    + "([^'\"]+)"    // capture group 1: plugin ID (any chars except quotes)
-                    + "['\"]"        // closing quote
-                    + "|"            // OR
+            "apply plugin:" // literal "apply plugin:"
+                    + "\\s*" // optional whitespace
+                    + "['\"]" // opening quote (single or double)
+                    + "([^'\"]+)" // capture group 1: plugin ID (any chars except quotes)
+                    + "['\"]" // closing quote
+                    + "|" // OR
                     + "plugins\\.apply\\(" // literal "plugins.apply("
-                    + "\\s*"         // optional whitespace
-                    + "['\"]"        // opening quote
-                    + "([^'\"]+)"    // capture group 2: plugin ID
-                    + "['\"]"        // closing quote
-                    + "\\s*"         // optional whitespace
-                    + "\\)"          // closing paren
-                    + "|"            // OR
+                    + "\\s*" // optional whitespace
+                    + "['\"]" // opening quote
+                    + "([^'\"]+)" // capture group 2: plugin ID
+                    + "['\"]" // closing quote
+                    + "\\s*" // optional whitespace
+                    + "\\)" // closing paren
+                    + "|" // OR
                     + "pluginManagement\\.apply\\(" // literal "pluginManagement.apply("
-                    + "\\s*"         // optional whitespace
-                    + "['\"]"        // opening quote
-                    + "([^'\"]+)"    // capture group 3: plugin ID
-                    + "['\"]"        // closing quote
-                    + "\\s*"         // optional whitespace
-                    + "\\)");        // closing paren
+                    + "\\s*" // optional whitespace
+                    + "['\"]" // opening quote
+                    + "([^'\"]+)" // capture group 3: plugin ID
+                    + "['\"]" // closing quote
+                    + "\\s*" // optional whitespace
+                    + "\\)"); // closing paren
 
     // Matches: id "plugin-id" or id "plugin-id" apply false/true
     // Captures: group 1 = plugin ID, group 2 = apply value (if present)
     private static final Pattern PLUGINS_BLOCK_ID = Pattern.compile(
-            "id"              // literal "id"
-                    + "\\s+"  // required whitespace
+            "id" // literal "id"
+                    + "\\s+" // required whitespace
                     + "['\"]" // opening quote
                     + "([^'\"]+)" // capture group 1: plugin ID
                     + "['\"]" // closing quote
-                    + "(?:"   // non-capturing group (optional):
+                    + "(?:" // non-capturing group (optional):
                     + "\\s+apply\\s+" // literal " apply "
-                    + "(false|true)"  // capture group 2: apply value
-                    + ")?");  // end optional group
+                    + "(false|true)" // capture group 2: apply value
+                    + ")?"); // end optional group
 
     // Matches: plugins { ... }
     // Captures everything between the braces
     private static final Pattern PLUGINS_BLOCK = Pattern.compile(
-            "plugins"    // literal "plugins"
+            "plugins" // literal "plugins"
                     + "\\s*" // optional whitespace
-                    + "\\{"  // opening brace
+                    + "\\{" // opening brace
                     + "([^}]*)" // capture group: any chars except }, greedily
-                    + "}",   // closing brace
+                    + "}", // closing brace
             Pattern.DOTALL);
 
     // Matches both single-line and multi-line comments:
     // 1. // ... to end of line
     // 2. /* ... */ across multiple lines
     private static final Pattern COMMENT = Pattern.compile(
-            "//"      // literal "//"
-                    + ".*"  // any chars to end of line
-                    + "|"   // OR
+            "//" // literal "//"
+                    + ".*" // any chars to end of line
+                    + "|" // OR
                     + "(?s)" // DOTALL mode for this alternative
                     + "/\\*" // literal "/*"
-                    + ".*?"  // any chars, non-greedy
+                    + ".*?" // any chars, non-greedy
                     + "\\*/"); // literal "*/"
 
     // Matches: plugins { } (with only whitespace inside)
     private static final Pattern EMPTY_PLUGINS = Pattern.compile(
-            "(?s)"       // DOTALL mode
+            "(?s)" // DOTALL mode
                     + "plugins" // literal "plugins"
-                    + "\\s*"    // optional whitespace
-                    + "\\{"     // opening brace
-                    + "\\s*"    // optional whitespace
+                    + "\\s*" // optional whitespace
+                    + "\\{" // opening brace
+                    + "\\s*" // optional whitespace
                     + "}");
 
     @Override

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
@@ -35,7 +35,6 @@ import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
-import com.sun.tools.javac.code.Type;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,19 +51,84 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
     private static final Matcher<ExpressionTree> STRING_TYPE = Matchers.isSubtypeOf("java.lang.String");
     private static final Matcher<ExpressionTree> FILE_EDITOR_TYPE =
             Matchers.isSubtypeOf("com.palantir.gradle.testing.files.ProjectFile.FileEditor");
+    private static final Matcher<ExpressionTree> GRADLE_FILE_TYPE =
+            Matchers.isSubtypeOf("com.palantir.gradle.testing.files.gradle.GradleFile");
 
-    private static final Pattern SIMPLE_PLUGIN_DECLARATIONS = Pattern.compile("apply plugin:\\s*['\"]([^'\"]+)['\"]"
-            + "|plugins\\.apply\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)"
-            + "|pluginManagement\\.apply\\(\\s*['\"]([^'\"]+)['\"]\\s*\\)");
-    private static final Pattern PLUGINS_BLOCK_ID =
-            Pattern.compile("id\\s+['\"]([^'\"]+)['\"](?:\\s+apply\\s+(false|true))?");
-    private static final Pattern PLUGINS_BLOCK = Pattern.compile("plugins\\s*\\{([^}]*)\\}", Pattern.DOTALL);
-    private static final Pattern COMMENT = Pattern.compile("//.*|(?s)/\\*.*?\\*/");
-    private static final Pattern EMPTY_PLUGINS = Pattern.compile("(?s)plugins\\s*\\{\\s*\\}");
+    // Matches three forms of plugin declarations:
+    // 1. apply plugin: "plugin-id"
+    // 2. plugins.apply("plugin-id")
+    // 3. pluginManagement.apply("plugin-id")
+    // Captures the plugin ID in one of three groups depending on which form matched
+    private static final Pattern SIMPLE_PLUGIN_DECLARATIONS = Pattern.compile(
+            "apply plugin:"          // literal "apply plugin:"
+                    + "\\s*"         // optional whitespace
+                    + "['\"]"        // opening quote (single or double)
+                    + "([^'\"]+)"    // capture group 1: plugin ID (any chars except quotes)
+                    + "['\"]"        // closing quote
+                    + "|"            // OR
+                    + "plugins\\.apply\\(" // literal "plugins.apply("
+                    + "\\s*"         // optional whitespace
+                    + "['\"]"        // opening quote
+                    + "([^'\"]+)"    // capture group 2: plugin ID
+                    + "['\"]"        // closing quote
+                    + "\\s*"         // optional whitespace
+                    + "\\)"          // closing paren
+                    + "|"            // OR
+                    + "pluginManagement\\.apply\\(" // literal "pluginManagement.apply("
+                    + "\\s*"         // optional whitespace
+                    + "['\"]"        // opening quote
+                    + "([^'\"]+)"    // capture group 3: plugin ID
+                    + "['\"]"        // closing quote
+                    + "\\s*"         // optional whitespace
+                    + "\\)");        // closing paren
+
+    // Matches: id "plugin-id" or id "plugin-id" apply false/true
+    // Captures: group 1 = plugin ID, group 2 = apply value (if present)
+    private static final Pattern PLUGINS_BLOCK_ID = Pattern.compile(
+            "id"              // literal "id"
+                    + "\\s+"  // required whitespace
+                    + "['\"]" // opening quote
+                    + "([^'\"]+)" // capture group 1: plugin ID
+                    + "['\"]" // closing quote
+                    + "(?:"   // non-capturing group (optional):
+                    + "\\s+apply\\s+" // literal " apply "
+                    + "(false|true)"  // capture group 2: apply value
+                    + ")?");  // end optional group
+
+    // Matches: plugins { ... }
+    // Captures everything between the braces
+    private static final Pattern PLUGINS_BLOCK = Pattern.compile(
+            "plugins"    // literal "plugins"
+                    + "\\s*" // optional whitespace
+                    + "\\{"  // opening brace
+                    + "([^}]*)" // capture group: any chars except }, greedily
+                    + "}",   // closing brace
+            Pattern.DOTALL);
+
+    // Matches both single-line and multi-line comments:
+    // 1. // ... to end of line
+    // 2. /* ... */ across multiple lines
+    private static final Pattern COMMENT = Pattern.compile(
+            "//"      // literal "//"
+                    + ".*"  // any chars to end of line
+                    + "|"   // OR
+                    + "(?s)" // DOTALL mode for this alternative
+                    + "/\\*" // literal "/*"
+                    + ".*?"  // any chars, non-greedy
+                    + "\\*/"); // literal "*/"
+
+    // Matches: plugins { } (with only whitespace inside)
+    private static final Pattern EMPTY_PLUGINS = Pattern.compile(
+            "(?s)"       // DOTALL mode
+                    + "plugins" // literal "plugins"
+                    + "\\s*"    // optional whitespace
+                    + "\\{"     // opening brace
+                    + "\\s*"    // optional whitespace
+                    + "}");
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (!isContentMethod(tree, state)
+        if (!isMethodThatModifiesBuildGradle(tree, state)
                 || GradlePluginTestHelpers.notGradlePluginTestsLibraryMethod(tree)
                 || GradlePluginTestHelpers.notWithinGradlePluginTests(tree, state)) {
             return Description.NO_MATCH;
@@ -76,7 +140,7 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
                 .orElse(Description.NO_MATCH);
     }
 
-    private static boolean isContentMethod(MethodInvocationTree tree, VisitorState state) {
+    private static boolean isMethodThatModifiesBuildGradle(MethodInvocationTree tree, VisitorState state) {
         return Optional.ofNullable(ASTHelpers.getSymbol(tree))
                 .filter(method -> !method.getParameters().isEmpty())
                 .filter(method -> tree.getArguments().stream()
@@ -84,14 +148,10 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
                         .map(firstArg ->
                                 STRING_TYPE.matches(firstArg, state) || FILE_EDITOR_TYPE.matches(firstArg, state))
                         .orElse(false))
-                .filter(method -> isProjectFileSubtype(method.enclClass(), state))
+                .filter(method -> Optional.ofNullable(ASTHelpers.getReceiver(tree))
+                        .map(receiver -> GRADLE_FILE_TYPE.matches(receiver, state))
+                        .orElse(false))
                 .isPresent();
-    }
-
-    private static boolean isProjectFileSubtype(Symbol.ClassSymbol classSymbol, VisitorState state) {
-        Type classType = classSymbol.type;
-        Type projectFileType = state.getTypeFromString("com.palantir.gradle.testing.files.ProjectFile");
-        return ASTHelpers.isSubtype(classType, projectFileType, state);
     }
 
     private Optional<Description> checkForPlugins(ExpressionTree arg, MethodInvocationTree tree, VisitorState state) {
@@ -123,7 +183,8 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
 
     private static boolean isInMethodChain(MethodInvocationTree tree, VisitorState state) {
         // Check if this is being called on a chain of content methods (receiver is a content method invocation)
-        if (ASTHelpers.getReceiver(tree) instanceof MethodInvocationTree receiver && isContentMethod(receiver, state)) {
+        if (ASTHelpers.getReceiver(tree) instanceof MethodInvocationTree receiver
+                && isMethodThatModifiesBuildGradle(receiver, state)) {
             return true;
         }
         // Check if something is being chained off of this call - walk up tree looking for a content MethodInvocation
@@ -133,7 +194,7 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
                 .filter(MethodInvocationTree.class::isInstance)
                 .map(MethodInvocationTree.class::cast)
                 .filter(parentMethod -> ASTHelpers.getReceiver(parentMethod) == tree)
-                .anyMatch(parentMethod -> isContentMethod(parentMethod, state));
+                .anyMatch(parentMethod -> isMethodThatModifiesBuildGradle(parentMethod, state));
     }
 
     private static Optional<String> getStringLiteral(ExpressionTree expr) {

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlock.java
@@ -128,7 +128,7 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (!isMethodThatModifiesBuildGradle(tree, state)
+        if (!isMethodWhichCouldAddPluginsManually(tree, state)
                 || GradlePluginTestHelpers.notGradlePluginTestsLibraryMethod(tree)
                 || GradlePluginTestHelpers.notWithinGradlePluginTests(tree, state)) {
             return Description.NO_MATCH;
@@ -140,7 +140,7 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
                 .orElse(Description.NO_MATCH);
     }
 
-    private static boolean isMethodThatModifiesBuildGradle(MethodInvocationTree tree, VisitorState state) {
+    private static boolean isMethodWhichCouldAddPluginsManually(MethodInvocationTree tree, VisitorState state) {
         return Optional.ofNullable(ASTHelpers.getSymbol(tree))
                 .filter(method -> !method.getParameters().isEmpty())
                 .filter(method -> tree.getArguments().stream()
@@ -184,7 +184,7 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
     private static boolean isInMethodChain(MethodInvocationTree tree, VisitorState state) {
         // Check if this is being called on a chain of content methods (receiver is a content method invocation)
         if (ASTHelpers.getReceiver(tree) instanceof MethodInvocationTree receiver
-                && isMethodThatModifiesBuildGradle(receiver, state)) {
+                && isMethodWhichCouldAddPluginsManually(receiver, state)) {
             return true;
         }
         // Check if something is being chained off of this call - walk up tree looking for a content MethodInvocation
@@ -194,7 +194,7 @@ public final class GradleTestPluginsBlock extends BugChecker implements BugCheck
                 .filter(MethodInvocationTree.class::isInstance)
                 .map(MethodInvocationTree.class::cast)
                 .filter(parentMethod -> ASTHelpers.getReceiver(parentMethod) == tree)
-                .anyMatch(parentMethod -> isMethodThatModifiesBuildGradle(parentMethod, state));
+                .anyMatch(parentMethod -> isMethodWhichCouldAddPluginsManually(parentMethod, state));
     }
 
     private static Optional<String> getStringLiteral(ExpressionTree expr) {

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestStringFormatting.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestStringFormatting.java
@@ -52,11 +52,11 @@ public final class GradleTestStringFormatting extends BugChecker implements BugC
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (GradlePluginTestHelpers.notGradlePluginTestsLibraryMethod(tree)) {
+        if (!GradlePluginTestHelpers.isGradlePluginTestsLibraryMethod(tree)) {
             return Description.NO_MATCH;
         }
 
-        if (GradlePluginTestHelpers.notWithinGradlePluginTests(tree, state)) {
+        if (!GradlePluginTestHelpers.isWithinGradlePluginTests(tree, state)) {
             return Description.NO_MATCH;
         }
 

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestStringFormatting.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestStringFormatting.java
@@ -30,13 +30,10 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.VariableTree;
-import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.code.Symbol;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.StreamSupport;
 
 @AutoService(BugChecker.class)
 @BugPattern(
@@ -55,7 +52,7 @@ public final class GradleTestStringFormatting extends BugChecker implements BugC
 
     @Override
     public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-        if (!GradlePluginTestHelpers.isGradlePluginTestsLibraryMethod(tree, state)) {
+        if (GradlePluginTestHelpers.notGradlePluginTestsLibraryMethod(tree)) {
             return Description.NO_MATCH;
         }
 
@@ -63,7 +60,7 @@ public final class GradleTestStringFormatting extends BugChecker implements BugC
             return Description.NO_MATCH;
         }
 
-        if (!hasFormatMethodOverload(tree, state)) {
+        if (!GradlePluginTestHelpers.hasFormatMethodOverload(tree, state)) {
             return Description.NO_MATCH;
         }
 
@@ -96,39 +93,11 @@ public final class GradleTestStringFormatting extends BugChecker implements BugC
         return Description.NO_MATCH;
     }
 
-    private static boolean hasFormatMethodOverload(MethodInvocationTree tree, VisitorState state) {
-        return Optional.ofNullable(ASTHelpers.getSymbol(tree))
-                .map(methodSymbol -> hasFormatOverloadInClass(methodSymbol, state))
-                .orElse(false);
-    }
-
-    private static boolean hasFormatOverloadInClass(Symbol.MethodSymbol methodSymbol, VisitorState state) {
-        String methodName = methodSymbol.getSimpleName().toString();
-        Symbol.ClassSymbol classSymbol = methodSymbol.enclClass();
-
-        return StreamSupport.stream(classSymbol.members().getSymbols().spliterator(), false)
-                .filter(Symbol.MethodSymbol.class::isInstance)
-                .map(Symbol.MethodSymbol.class::cast)
-                .filter(method -> method.getSimpleName().toString().equals(methodName))
-                .filter(method ->
-                        ASTHelpers.hasAnnotation(method, "com.google.errorprone.annotations.FormatMethod", state))
-                .anyMatch(method -> hasFormatStringParameter(method, state));
-    }
-
-    private static boolean hasFormatStringParameter(Symbol.MethodSymbol method, VisitorState state) {
-        return method.getParameters().stream()
-                .anyMatch(param ->
-                        ASTHelpers.hasAnnotation(param, "com.google.errorprone.annotations.FormatString", state));
-    }
-
     private static boolean isIdentifierInitialisedWithFormattedString(IdentifierTree identifier, VisitorState state) {
         return Optional.ofNullable(ASTHelpers.getSymbol(identifier))
                 .filter(Symbol.VarSymbol.class::isInstance)
                 .map(Symbol.VarSymbol.class::cast)
-                .map(varSymbol -> JavacTrees.instance(state.context).getTree(varSymbol))
-                .filter(VariableTree.class::isInstance)
-                .map(VariableTree.class::cast)
-                .map(VariableTree::getInitializer)
+                .flatMap(varSymbol -> GradlePluginTestHelpers.findVariableInitializer(varSymbol, state))
                 .map(initializer -> FORMATTED_STRING.matches(initializer, state))
                 .orElse(false);
     }

--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestTemporaryFile.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestTemporaryFile.java
@@ -56,7 +56,7 @@ public final class GradleTestTemporaryFile extends BugChecker
             return Description.NO_MATCH;
         }
 
-        if (GradlePluginTestHelpers.notWithinGradlePluginTests(tree, state)) {
+        if (!GradlePluginTestHelpers.isWithinGradlePluginTests(tree, state)) {
             return Description.NO_MATCH;
         }
 
@@ -69,7 +69,7 @@ public final class GradleTestTemporaryFile extends BugChecker
             return Description.NO_MATCH;
         }
 
-        if (GradlePluginTestHelpers.notWithinGradlePluginTests(tree, state)) {
+        if (!GradlePluginTestHelpers.isWithinGradlePluginTests(tree, state)) {
             return Description.NO_MATCH;
         }
 

--- a/gradle-plugin-testing-error-prone/src/test/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlockTest.java
+++ b/gradle-plugin-testing-error-prone/src/test/java/com/palantir/gradle/testing/errorprone/GradleTestPluginsBlockTest.java
@@ -1,0 +1,528 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+class GradleTestPluginsBlockTest {
+    @Test
+    void catch_all_plugin_patterns() {
+        test("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append("apply plugin: 'java'");
+
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append("plugins.apply('java')");
+
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append("pluginManagement.apply('java')");
+
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append("plugins { id 'java' }");
+
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append("plugins { id 'java' apply false }");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void catch_quote_variations() {
+        test("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append("apply plugin: \\"java\\"");
+
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append(\"""
+                        plugins {
+                            id "java"
+                            id 'application'
+                        }
+                        \""");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void catch_variable_reference_no_autofix() {
+        testUnchanged("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    String content = "apply plugin: 'java'";
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append(content);
+                }
+            }
+            """);
+    }
+
+    @Test
+    void allow_all_valid_cases() {
+        test("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    // Correct API usage
+                    file.plugins().add("java");
+
+                    // No plugins block context
+                    file.append("id 'java'");
+
+                    // Non-plugin content
+                    file.append("repositories { mavenCentral() }");
+
+                    // Comments should be ignored
+                    file.append("// apply plugin: 'java'");
+                    file.append("/* plugins.apply('java') */");
+                    file.append("\""
+                                /*
+                                  plugins.apply('java')
+                                */
+                                "\"");
+
+                    // Word 'id' in other contexts
+                    file.append("description = 'This is a valid project id string'");
+                    file.append("tasks.register('myTask') { id 'something' }");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void allow_outside_gradle_plugin_tests() {
+        test("""
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append("apply plugin: 'java'");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_simple_patterns() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append("apply plugin: 'java'");
+                    // other code
+                    file.append("plugins.apply('application')");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.plugins().add("java");
+                    // other code
+                    file.plugins().add("application");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_with_content() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append(\"""
+                        repositories { mavenCentral() }
+                        apply plugin: 'java'
+                        dependencies { }
+                        \""");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append(\"""
+                        repositories { mavenCentral() }
+
+                        dependencies { }
+                        \""");
+                    file.plugins().add("java");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_multiple_plugins() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append(\"""
+                        apply plugin: 'java'
+                        repositories { }
+                        apply plugin: 'application'
+                        tasks { }
+                        \""");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append(\"""
+                        repositories { }
+
+                        tasks { }
+                        \""");
+                    file.plugins().add("java").add("application");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_plugins_block() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append("plugins { id 'java' }");
+
+                    file.append(\"""
+                        plugins {
+                            id 'application'
+                            id 'maven-publish'
+                        }
+                        \""");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.plugins().add("java");
+
+                    file.plugins().add("application").add("maven-publish");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_apply_false() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append(\"""
+                        plugins {
+                            id 'java'
+                            id 'application' apply false
+                            id 'maven-publish'
+                        }
+                        \""");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.plugins().add("java").addWithoutApply("application").add("maven-publish");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_mixed_quote_styles() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append(\"""
+                        plugins {
+                            id "java"
+                            id 'application'
+                        }
+                        \""");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.plugins().add("java").add("application");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_all_content_methods() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.overwrite("apply plugin: 'java'");
+                    file.prepend("apply plugin: 'application'");
+                    file.append("apply plugin: 'maven-publish'");
+                    file.appendLine("apply plugin: 'idea'");
+                    file.prependLine("apply plugin: 'eclipse'");
+                    file.edit(text -> text + "apply plugin: 'java'");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.plugins().add("java");
+                    file.plugins().add("application");
+                    file.plugins().add("maven-publish");
+                    file.plugins().add("idea");
+                    file.plugins().add("eclipse");
+                    file.plugins().add("java");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_multiple_plugins_calls() {
+        testFix("""
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append(\"""
+                    plugins {
+                        id 'java'
+                        id 'application'
+                    }
+
+                    // some other code
+
+                    plugins {
+                        id 'java'
+                        id 'application'
+                    }
+                    \""");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append(\"""
+                    // some other code
+                    \""");
+                    file.plugins().add("java").add("application");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void catch_chained_append_methods() {
+        testUnchanged("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.append("repositories { mavenCentral() }")
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                        .append("apply plugin: 'java'");
+
+                    // BUG: Diagnostic contains: GradleTestPluginsBlock
+                    file.append("apply plugin: 'application'")
+                        .append("dependencies { }");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void catch_varargs_overloads_no_autofix() {
+        testUnchanged("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    // BUG: Diagnostic contains: Plugins must be added using .plugins().add()
+                    file.overwrite("//other content \\n apply plugin: '%s'", "arg1");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_overwrite_with_text_block() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.overwrite(""\"
+                        dependencies {}
+                        apply plugin: 'java'
+                        ""\");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.overwrite(""\"
+                        dependencies {}
+                        ""\");
+                    file.plugins().add("java");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_block_lambda() {
+        testFix("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.edit(text -> {
+                        return text + "apply plugin: 'java'";
+                    });
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.gradle.GradleFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(GradleFile file) {
+                    file.plugins().add("java");
+                }
+            }
+            """);
+    }
+
+    private void test(@Language("Java") String javaCode) {
+        CompilationTestHelper compilationTestHelper =
+                CompilationTestHelper.newInstance(GradleTestPluginsBlock.class, getClass());
+        compilationTestHelper.addSourceLines("TestClass.java", javaCode).doTest();
+    }
+
+    private void testFix(@Language("Java") String input, @Language("Java") String expected) {
+        BugCheckerRefactoringTestHelper refactoringTestHelper =
+                BugCheckerRefactoringTestHelper.newInstance(GradleTestPluginsBlock.class, getClass());
+        refactoringTestHelper
+                .addInputLines("TestClass.java", input)
+                .addOutputLines("TestClass.java", expected)
+                .doTest();
+    }
+
+    private void testUnchanged(@Language("Java") String javaCode) {
+        BugCheckerRefactoringTestHelper refactoringTestHelper =
+                BugCheckerRefactoringTestHelper.newInstance(GradleTestPluginsBlock.class, getClass());
+        refactoringTestHelper
+                .addInputLines("TestClass.java", javaCode)
+                .expectUnchanged()
+                .doTest();
+    }
+}

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -49,7 +49,7 @@ public class PluginTestingPlugin implements Plugin<Project> {
     static final List<String> CORE_MAVEN_NAMES =
             List.of("plugin-testing-core", "configuration-cache-spec", "gradle-plugin-testing-junit");
 
-    public static final Set<String> PATCHABLE_CHECKS = Set.of("GradleTestStringFormatting");
+    public static final Set<String> PATCHABLE_CHECKS = Set.of("GradleTestStringFormatting", "GradleTestPluginsBlock");
 
     private static final String MAVEN_GROUP = "com.palantir.gradle.plugintesting";
 


### PR DESCRIPTION
### Error Prone Check: `GradleTestPluginsBlock`

A new Error Prone check enforces usage of the structured API and prevents problematic patterns:

**What it catches:**
- `apply plugin: 'java'` - Old-style plugin application
- `plugins.apply('java')` - Direct plugin application
- `pluginManagement.apply('java')` - Plugin management application
- `plugins { id 'java' }` - Direct plugins block manipulation in strings
- Any variation of the above in string literals, text blocks, or lambda expressions

**Autofix capabilities:**
- Automatically converts old-style declarations to `.plugins().add()` calls
- Extracts plugins from strings and generates proper API calls
- Preserves other content in the string/lambda
- Handles multiple plugins in a single string

**Limitations of autofix:**
1. **No autofix for variable references** - When the plugin declaration is in a variable, only a warning is shown (no automatic fix)
2. **No autofix for `@FormatMethod` calls** - When using formatting methods (e.g., `append("plugins { id '%s' }", pluginId)`), autofix is disabled because the formatting logic would very complex
3. **Only works in `@GradlePluginTests`** - Check only applies to test classes annotated with `@GradlePluginTests`
4. **Library methods only** - Only validates calls to methods in `com.palantir.gradle.testing.*` package

**Example transformation:**
```java
// Before (triggers error)
file.append("""
    repositories { mavenCentral() }
    apply plugin: 'java'
    dependencies { }
    """);

// After (autofix)
file.append("""
    repositories { mavenCentral() }
    
    dependencies { }
    """);
file.plugins().add("java");
```

> Note: most of the changes in `GradlePluginTestHelpers` and `GradleTestStringFormatting` are simply extracting existing methods to the helper class so they can be used more widely 

