### PR TITLE
Match braces rather than regex for buildscript matching

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/Plugins.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/Plugins.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.testing.files.gradle;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -42,18 +43,7 @@ public final class Plugins {
                     + "\\n?", // optional newline after
             Pattern.DOTALL);
 
-    // Matches: buildscript { ... } with ONE level of nested braces allowed
-    private static final Pattern BUILDSCRIPT_BLOCK_PATTERN = Pattern.compile(
-            "buildscript" // literal "buildscript"
-                    + "\\s*" // optional whitespace
-                    + "\\{" // opening brace
-                    + "(?:" // non-capturing group, repeated:
-                    + "[^{}]" //   either: any char that's not a brace
-                    + "|" //   OR
-                    + "\\{[^{}]*}" //   a pair of braces with non-brace content inside
-                    + ")*" // repeat the group zero or more times
-                    + "}", // closing brace
-            Pattern.DOTALL);
+    private static final Pattern BUILDSCRIPT_PATTERN = Pattern.compile("buildscript\\s*\\{");
 
     private final GradleFile file;
 
@@ -99,13 +89,13 @@ public final class Plugins {
     }
 
     private static String repositionPluginsBlockWithContent(String textWithoutPluginsBlock, String pluginsBlock) {
-        Matcher buildscriptMatcher = BUILDSCRIPT_BLOCK_PATTERN.matcher(textWithoutPluginsBlock);
+        OptionalInt buildscriptEnd = findBuildScriptBlockEnd(textWithoutPluginsBlock);
 
         // plugins block must go after buildscript and above all else
-        if (buildscriptMatcher.find()) {
-            int insertPosition = buildscriptMatcher.end();
-            String suffix = textWithoutPluginsBlock.substring(insertPosition).replaceFirst("^\n", "");
-            return textWithoutPluginsBlock.substring(0, insertPosition) + "\n" + pluginsBlock + suffix;
+        if (buildscriptEnd.isPresent()) {
+            String suffix =
+                    textWithoutPluginsBlock.substring(buildscriptEnd.getAsInt()).replaceFirst("^\n", "");
+            return textWithoutPluginsBlock.substring(0, buildscriptEnd.getAsInt()) + "\n" + pluginsBlock + suffix;
         }
 
         return pluginsBlock + textWithoutPluginsBlock;
@@ -145,5 +135,28 @@ public final class Plugins {
         String pluginsBlock = "plugins {\n" + pluginsContent + "\n}\n";
 
         return repositionPluginsBlockWithContent(textWithoutPluginsBlock, pluginsBlock);
+    }
+
+    private static OptionalInt findBuildScriptBlockEnd(String text) {
+        Matcher matcher = BUILDSCRIPT_PATTERN.matcher(text);
+        if (!matcher.find()) {
+            return OptionalInt.empty();
+        }
+        int openBraceIndex = matcher.end() - 1; // position of '{'
+
+        // Match braces
+        int depth = 1;
+        for (int i = openBraceIndex + 1; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (ch == '{') {
+                depth++;
+            } else if (ch == '}') {
+                depth--;
+            }
+            if (depth == 0) {
+                return OptionalInt.of(i + 1); // Return index after closing '}'
+            }
+        }
+        return OptionalInt.empty();
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/PluginsUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/PluginsUsagesTest.java
@@ -191,4 +191,60 @@ class PluginsUsagesTest {
             }
             """);
     }
+
+    @Test
+    void plugins_block_placed_after_buildscript_with_two_levels_of_nesting(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("""
+            buildscript {
+                repositories {
+                    maven {}
+                }
+            }
+            """);
+
+        rootProject.buildGradle().plugins().add("java");
+
+        rootProject.buildGradle().assertThat().hasContent("""
+            buildscript {
+                repositories {
+                    maven {}
+                }
+            }
+            plugins {
+                id 'java'
+            }
+            """);
+    }
+
+    @Test
+    void plugins_block_placed_after_buildscript_with_deep_nesting(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("""
+            buildscript {
+                repositories {
+                    maven {
+                        credentials {
+                            username = "user"
+                        }
+                    }
+                }
+            }
+            """);
+
+        rootProject.buildGradle().plugins().add("java");
+
+        rootProject.buildGradle().assertThat().hasContent("""
+            buildscript {
+                repositories {
+                    maven {
+                        credentials {
+                            username = "user"
+                        }
+                    }
+                }
+            }
+            plugins {
+                id 'java'
+            }
+            """);
+    }
 }


### PR DESCRIPTION
## Before this PR
Previously we used a regex that would only match one level of nested {} withing buildscript:

For example, this correctly returns true:
```java
BUILDSCRIPT_BLOCK_PATTERN.matcher("buildscript{repositories{}}").find();
```
While this incorrectly returns false:
```java
BUILDSCRIPT_BLOCK_PATTERN.matcher("buildscript{repositories{maven{}}}").find();
```
## After this PR
now we match braces so can cope with any depth of nesting within the buildscript block
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

