### PR TITLE
Add to guide based on claude feedback

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -163,8 +163,13 @@ All project files inherit from `ProjectFile<T>` with these methods:
 
 All methods support `String.format()` syntax for dynamic values.  The varargs overload provides better IDE support with syntax highlighting and is enforced by the `GradleTestStringFormatting` Error Prone check.
 ```java
+// ✅ CORRECT - Use varargs overload
 String version = "1.0.0";
 project.buildGradle().append("version = '%s'", version);
+
+// ❌ INCORRECT - Will fail with GradleTestStringFormatting error
+project.buildGradle().append("version = '%s'".formatted(version));
+project.buildGradle().append(String.format("version = '%s'", version));
 ```
 
 **Reading file contents:**
@@ -228,6 +233,7 @@ Use the structured `plugins()` API to add plugins:
 **Important:** Always use the `plugins()` API instead of manually writing plugin blocks in `append()` or `overwrite()` calls. The `plugins()` API ensures correct positioning after `buildscript {}` blocks and prevents duplicate plugin entries.
 
 ```java
+// ✅ CORRECT - Use the plugins() API
 @Test
 void add_plugins(RootProject project) {
     // Add plugins individually
@@ -240,6 +246,15 @@ void add_plugins(RootProject project) {
     project.buildGradle()
         .plugins()
         .addWithoutApply("com.palantir.baseline");
+}
+```
+
+```java
+// ❌ INCORRECT - Will fail with GradleTestPluginsBlock error
+void add_plugins(RootProject project) {
+project.buildGradle().append("""
+    apply plugin: 'groovy'
+    """);
 }
 ```
 
@@ -361,6 +376,11 @@ void create_versions_props(RootProject project) {
         .appendProperty("com.google.guava:*", "32.1.0-jre")
         .appendProperty("org.slf4j:*", "2.0.9");
 }
+```
+
+```java
+// ❌ INCORRECT - Don't manually format properties
+project.gradlePropertiesFile().append("key=value\n");
 ```
 
 ### YAML Files

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -163,13 +163,8 @@ All project files inherit from `ProjectFile<T>` with these methods:
 
 All methods support `String.format()` syntax for dynamic values.  The varargs overload provides better IDE support with syntax highlighting and is enforced by the `GradleTestStringFormatting` Error Prone check.
 ```java
-// ✅ CORRECT - Use varargs overload
 String version = "1.0.0";
 project.buildGradle().append("version = '%s'", version);
-
-// ❌ INCORRECT - Will fail with GradleTestStringFormatting error
-project.buildGradle().append("version = '%s'".formatted(version));
-project.buildGradle().append(String.format("version = '%s'", version));
 ```
 
 **Reading file contents:**
@@ -233,7 +228,6 @@ Use the structured `plugins()` API to add plugins:
 **Important:** Always use the `plugins()` API instead of manually writing plugin blocks in `append()` or `overwrite()` calls. The `plugins()` API ensures correct positioning after `buildscript {}` blocks and prevents duplicate plugin entries.
 
 ```java
-// ✅ CORRECT - Use the plugins() API
 @Test
 void add_plugins(RootProject project) {
     // Add plugins individually
@@ -246,15 +240,6 @@ void add_plugins(RootProject project) {
     project.buildGradle()
         .plugins()
         .addWithoutApply("com.palantir.baseline");
-}
-```
-
-```java
-// ❌ INCORRECT - Will fail with GradleTestPluginsBlock error
-void add_plugins(RootProject project) {
-project.buildGradle().append("""
-    apply plugin: 'groovy'
-    """);
 }
 ```
 
@@ -376,11 +361,6 @@ void create_versions_props(RootProject project) {
         .appendProperty("com.google.guava:*", "32.1.0-jre")
         .appendProperty("org.slf4j:*", "2.0.9");
 }
-```
-
-```java
-// ❌ INCORRECT - Don't manually format properties
-project.gradlePropertiesFile().append("key=value\n");
 ```
 
 ### YAML Files

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -161,9 +161,15 @@ All project files inherit from `ProjectFile<T>` with these methods:
 - **`createEmpty()`** - Create an empty file
 - **`assertThat()`** - AssertJ path assertions
 
-All methods support `String.format()` syntax:
+All methods support `String.format()` syntax for dynamic values.  The varargs overload provides better IDE support with syntax highlighting and is enforced by the `GradleTestStringFormatting` Error Prone check.
 ```java
-project.buildGradle().append("version = '%s'", "1.0.0");
+// ✅ CORRECT - Use varargs overload
+String version = "1.0.0";
+project.buildGradle().append("version = '%s'", version);
+
+// ❌ INCORRECT - Will fail with GradleTestStringFormatting error
+project.buildGradle().append("version = '%s'".formatted(version));
+project.buildGradle().append(String.format("version = '%s'", version));
 ```
 
 **Reading file contents:**
@@ -224,8 +230,10 @@ void configure_settings(RootProject project) {
 ### Plugin Management
 
 Use the structured `plugins()` API to add plugins:
+**Important:** Always use the `plugins()` API instead of manually writing plugin blocks in `append()` or `overwrite()` calls. The `plugins()` API ensures correct positioning after `buildscript {}` blocks and prevents duplicate plugin entries.
 
 ```java
+// ✅ CORRECT - Use the plugins() API
 @Test
 void add_plugins(RootProject project) {
     // Add plugins individually
@@ -241,7 +249,14 @@ void add_plugins(RootProject project) {
 }
 ```
 
-**Important:** Always use the `plugins()` API instead of manually writing plugin blocks in `append()` or `overwrite()` calls. The `plugins()` API ensures correct positioning after `buildscript {}` blocks and prevents duplicate plugin entries.
+```java
+// ❌ INCORRECT - Will fail with GradleTestPluginsBlock error
+void add_plugins(RootProject project) {
+project.buildGradle().append("""
+    apply plugin: 'groovy'
+    """);
+}
+```
 
 #### Testing with External Plugins
 
@@ -296,7 +311,7 @@ void create_custom_gradle_files(RootProject project) {
 
 ### Java Source Files
 
-Write and manipulate Java source:
+Write and manipulate Java source.  The `writeClass()` method from `JavaSrcDir` (accessed via `project.mainSourceSet().java()` or `project.sourceSet("name").java()`) automatically parses the Java source code to extract the package and class name, then creates the file at the correct path.
 
 ```java
 @Test
@@ -343,7 +358,7 @@ void create_java_class(RootProject project) {
 
 ### Properties Files
 
-Manage `gradle.properties` and other properties files:
+Manage `gradle.properties` and other properties files.  Use `appendProperty(key, value)` for properties files, not `append()`
 
 ```java
 @Test
@@ -361,6 +376,11 @@ void create_versions_props(RootProject project) {
         .appendProperty("com.google.guava:*", "32.1.0-jre")
         .appendProperty("org.slf4j:*", "2.0.9");
 }
+```
+
+```java
+// ❌ INCORRECT - Don't manually format properties
+project.gradlePropertiesFile().append("key=value\n");
 ```
 
 ### YAML Files


### PR DESCRIPTION
## Before this PR
These are changes proposed by claude when I asked it to improve the guide to help it convert tests.  It's changes were actually more verbose so I modified them some so the guide is still useful  for humans but also help the AI. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

