### PR TITLE
don't check if configuration time error that isn't related to configuration cache error

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
@@ -68,6 +68,12 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
     @Override
     public InvocationResult buildsWithFailure() {
         InvocationResult result = initialGradleInvocation.buildsWithFailure();
+
+        // check if there is a configuration time error that isn't related to configuration cache errors
+        if (result.output().contains("org.gradle.api.ProjectConfigurationException:")) {
+            return result;
+        }
+
         assertConfigCacheStored(result);
         InvocationResult configurationCacheResult = secondGradleInvocation.buildsSuccessfully();
         assertConfigCacheReused(configurationCacheResult);

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
@@ -69,8 +69,10 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
     public InvocationResult buildsWithFailure() {
         InvocationResult result = initialGradleInvocation.buildsWithFailure();
 
-        // check if there is a configuration time error that isn't related to configuration cache errors
-        if (result.output().contains("org.gradle.api.ProjectConfigurationException:")) {
+        // check if there is a configuration time error that isn't related to configuration cache errors or any script
+        // exceptions
+        if (result.output().contains("org.gradle.api.ProjectConfigurationException:")
+                || result.output().contains("org.gradle.api.GradleScriptException:")) {
             return result;
         }
 

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
@@ -183,17 +183,12 @@ class ConfigurationCacheTests {
     @Test
     void configuration_time_errors_do_not_run_dry_run(GradleInvoker invoker, RootProject rootProject) {
         rootProject.buildGradle().append("""
-            project.afterEvaluate(_p -> {
-                if (!project.getRootProject().getPlugins().hasPlugin("randomPlugin")) {
-                    throw new IllegalStateException("Missing a random plugin");
-                }
-            });
+            afterEvaluate {
+                throw new IllegalStateException("Configuration time issue");
+            }
             """);
 
         InvocationResult result = invoker.withArgs("help").buildsWithFailure();
-        result.assertThat()
-                .output()
-                .contains("Missing a random plugin")
-                .contains("org.gradle.api.ProjectConfigurationException:");
+        result.assertThat().output().contains("org.gradle.api.ProjectConfigurationException:");
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
@@ -179,4 +179,21 @@ class ConfigurationCacheTests {
                 .hasMessageContaining("Configuration cache incompatibility: Build execution failed.")
                 .hasMessageContaining("1 problem was found storing the configuration cache.");
     }
+
+    @Test
+    void configuration_time_errors_do_not_run_dry_run(GradleInvoker invoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            project.afterEvaluate(_p -> {
+                if (!project.getRootProject().getPlugins().hasPlugin("randomPlugin")) {
+                    throw new IllegalStateException("Missing a random plugin");
+                }
+            });
+            """);
+
+        InvocationResult result = invoker.withArgs("help").buildsWithFailure();
+        result.assertThat()
+                .output()
+                .contains("Missing a random plugin")
+                .contains("org.gradle.api.ProjectConfigurationException:");
+    }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
@@ -191,4 +191,14 @@ class ConfigurationCacheTests {
         InvocationResult result = invoker.withArgs("help").buildsWithFailure();
         result.assertThat().output().contains("org.gradle.api.ProjectConfigurationException:");
     }
+
+    @Test
+    void script_complication_errors_do_not_run_dry_run(GradleInvoker invoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            throw new IllegalStateException("Configuration time issue");
+            """);
+
+        InvocationResult result = invoker.withArgs("help").buildsWithFailure();
+        result.assertThat().output().contains("org.gradle.api.GradleScriptException:");
+    }
 }


### PR DESCRIPTION
## Before this PR
We would always check the configuration cache was stored and that dry-run was succesful
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
after https://github.com/palantir/gradle-shadow-jar/pull/895 we noticed we dont want to check the store and dry-run if the configuration time error that isn't related to configuration cache error
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

