### PR TITLE
Add `discoverGradlePluginTestsWithDisabledConfigurationCache`  task

### DIFF
--- a/discover-tests-cli/src/main/java/com/palantir/gradle/plugintesting/WithAnnotationsCommand.java
+++ b/discover-tests-cli/src/main/java/com/palantir/gradle/plugintesting/WithAnnotationsCommand.java
@@ -38,14 +38,8 @@ public final class WithAnnotationsCommand extends TestClassesDiscoverer {
 
     @Override
     protected Filter<?> getFilter() {
-        List<? extends Class<? extends Annotation>> includedClasses = includedAnnotations.stream()
-                .map(WithAnnotationsCommand::getClassAnnotation)
-                .mapMulti(Optional<Class<? extends Annotation>>::ifPresent)
-                .toList();
-        List<? extends Class<? extends Annotation>> excludedClasses = excludedAnnotations.stream()
-                .map(WithAnnotationsCommand::getClassAnnotation)
-                .mapMulti(Optional<Class<? extends Annotation>>::ifPresent)
-                .toList();
+        List<? extends Class<? extends Annotation>> includedClasses = asAnnotationClasses(includedAnnotations);
+        List<? extends Class<? extends Annotation>> excludedClasses = asAnnotationClasses(excludedAnnotations);
         return new PostDiscoveryFilter() {
             @Override
             public FilterResult apply(TestDescriptor testDescriptor) {
@@ -66,6 +60,13 @@ public final class WithAnnotationsCommand extends TestClassesDiscoverer {
                         .orElseGet(() -> FilterResult.excluded("Not a class source"));
             }
         };
+    }
+
+    private static List<Class<? extends Annotation>> asAnnotationClasses(List<String> annotations) {
+        return annotations.stream()
+                .map(WithAnnotationsCommand::getClassAnnotation)
+                .mapMulti(Optional<Class<? extends Annotation>>::ifPresent)
+                .toList();
     }
 
     private static boolean hasAnyClassAnnotations(

--- a/discover-tests-cli/src/main/java/com/palantir/gradle/plugintesting/WithAnnotationsCommand.java
+++ b/discover-tests-cli/src/main/java/com/palantir/gradle/plugintesting/WithAnnotationsCommand.java
@@ -33,9 +33,16 @@ public final class WithAnnotationsCommand extends TestClassesDiscoverer {
     @Option(names = "--include", split = ",", description = "List of testClasses with annotations to include")
     private List<String> includedAnnotations;
 
+    @Option(names = "--exclude", split = ",", description = "List of testClasses with annotations to exclude")
+    private List<String> excludedAnnotations;
+
     @Override
     protected Filter<?> getFilter() {
-        List<? extends Class<? extends Annotation>> annotationClasses = includedAnnotations.stream()
+        List<? extends Class<? extends Annotation>> includedClasses = includedAnnotations.stream()
+                .map(WithAnnotationsCommand::getClassAnnotation)
+                .mapMulti(Optional<Class<? extends Annotation>>::ifPresent)
+                .toList();
+        List<? extends Class<? extends Annotation>> excludedClasses = excludedAnnotations.stream()
                 .map(WithAnnotationsCommand::getClassAnnotation)
                 .mapMulti(Optional<Class<? extends Annotation>>::ifPresent)
                 .toList();
@@ -46,7 +53,10 @@ public final class WithAnnotationsCommand extends TestClassesDiscoverer {
                         .getSource()
                         .map(TestClassesDiscoverer::getTestClassFromSource)
                         .map(testClass -> {
-                            if (hasAnyClassAnnotations(testClass, annotationClasses)) {
+                            if (hasAnyClassAnnotations(testClass, excludedClasses)) {
+                                return FilterResult.excluded(
+                                        String.format("%s has an excluded annotation", testDescriptor));
+                            } else if (hasAnyClassAnnotations(testClass, includedClasses)) {
                                 return FilterResult.included(
                                         String.format("%s has an allowlisted annotation", testDescriptor));
                             }

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -167,12 +167,18 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
     }
 
     private static void addTestClassesDiscoveryTasks(Project project) {
-        project.getTasks().register("discoverGradlePluginTests", DiscoverTestClassesTask.class, task -> {
-            task.getTestClassType().set("java");
-            task.getExtraArguments()
-                    .addAll(List.of(
-                            "withAnnotations", "--include", "com.palantir.gradle.testing.junit.GradlePluginTests"));
-        });
+        project.getTasks()
+                .register(
+                        "discoverDisabledConfigurationCacheGradlePluginTests", DiscoverTestClassesTask.class, task -> {
+                            task.getTestClassType().set("java");
+                            task.getExtraArguments()
+                                    .addAll(List.of(
+                                            "withAnnotations",
+                                            "--include",
+                                            "com.palantir.gradle.testing.junit.GradlePluginTests",
+                                            "--exclude",
+                                            "com.palantir.gradle.testing.junit.DisabledConfigurationCache"));
+                        });
 
         project.getTasks().register("discoverNebulaTestClassesToMigrate", DiscoverTestClassesTask.class, task -> {
             task.getTestClassType().set("groovy");

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -169,7 +169,9 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
     private static void addTestClassesDiscoveryTasks(Project project) {
         project.getTasks()
                 .register(
-                        "discoverDisabledConfigurationCacheGradlePluginTests", DiscoverTestClassesTask.class, task -> {
+                        "discoverGradlePluginTestsWithDisabledConfigurationCache",
+                        DiscoverTestClassesTask.class,
+                        task -> {
                             task.getTestClassType().set("java");
                             task.getExtraArguments()
                                     .addAll(List.of(

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -242,6 +242,34 @@ class PluginTestingJunitPluginTest {
             package test;
 
             import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.junit.DisabledConfigurationCache;
+            import java.nio.file.Files;
+            import org.junit.jupiter.api.Nested;
+            import org.junit.jupiter.api.Test;
+
+            @DisabledConfigurationCache
+            @GradlePluginTests
+            class NoConfigCacheGradlePluginTestClass {
+                @Test
+                void test() throws Exception {
+                    Files.createTempDirectory("prefix");
+                }
+
+                @Nested
+                class NestedGradlePluginTestClass {
+
+                    @Test
+                    void nested_test() throws Exception {
+                        Files.createTempDirectory("other");
+                    }
+                }
+            }
+            """);
+
+        rootProject.testSourceSet().java().writeClass("""
+            package test;
+
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
             import org.junit.jupiter.api.Test;
 
             class JunitTest {
@@ -251,7 +279,7 @@ class PluginTestingJunitPluginTest {
             }
             """);
 
-        gradle.withArgs("discoverGradlePluginTests", "--info").buildsSuccessfully();
+        gradle.withArgs("discoverDisabledConfigurationCacheGradlePluginTests").buildsSuccessfully();
         assertThat(readTestClassesPaths(rootProject, "java"))
                 .containsExactlyInAnyOrder("src/test/java/test/GradlePluginTestClass.java");
     }

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -247,21 +247,12 @@ class PluginTestingJunitPluginTest {
             import org.junit.jupiter.api.Nested;
             import org.junit.jupiter.api.Test;
 
-            @DisabledConfigurationCache
             @GradlePluginTests
+            @DisabledConfigurationCache
             class NoConfigCacheGradlePluginTestClass {
                 @Test
                 void test() throws Exception {
                     Files.createTempDirectory("prefix");
-                }
-
-                @Nested
-                class NestedGradlePluginTestClass {
-
-                    @Test
-                    void nested_test() throws Exception {
-                        Files.createTempDirectory("other");
-                    }
                 }
             }
             """);
@@ -279,7 +270,8 @@ class PluginTestingJunitPluginTest {
             }
             """);
 
-        gradle.withArgs("discoverDisabledConfigurationCacheGradlePluginTests").buildsSuccessfully();
+        gradle.withArgs("discoverGradlePluginTestsWithDisabledConfigurationCache")
+                .buildsSuccessfully();
         assertThat(readTestClassesPaths(rootProject, "java"))
                 .containsExactlyInAnyOrder("src/test/java/test/GradlePluginTestClass.java");
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Needed by the internal excavator that does the migration to CC. The excavator needs to generate all the test files that have `@DisabledConfigurationCache` annotation such that for each one of them it can try to remove the annotation & check if the tests are compatible with CC.

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `discoverGradlePluginTestsWithDisabledConfigurationCache`  task
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

