### PR TITLE
Fix `discoverGradlePluginTestsWithDisabledConfigurationCache`

### DIFF
--- a/discover-tests-cli/src/main/java/com/palantir/gradle/plugintesting/SubClassesOfCommand.java
+++ b/discover-tests-cli/src/main/java/com/palantir/gradle/plugintesting/SubClassesOfCommand.java
@@ -29,10 +29,10 @@ import picocli.CommandLine.Option;
 @Command(name = "subClassesOf", description = "Test classes options")
 public final class SubClassesOfCommand extends TestClassesDiscoverer {
 
-    @Option(names = "--include", split = ",", description = "List of sub-class names to include")
+    @Option(names = "--include", split = ",", description = "List of sub-class names to include", defaultValue = "")
     private List<String> classNames;
 
-    @Option(names = "--exclude", split = ",", description = "List of sub-class names to exclude")
+    @Option(names = "--exclude", split = ",", description = "List of sub-class names to exclude", defaultValue = "")
     private List<String> excludedClassNames;
 
     @Override

--- a/discover-tests-cli/src/main/java/com/palantir/gradle/plugintesting/WithAnnotationsCommand.java
+++ b/discover-tests-cli/src/main/java/com/palantir/gradle/plugintesting/WithAnnotationsCommand.java
@@ -30,16 +30,16 @@ import picocli.CommandLine.Option;
 @Command(name = "withAnnotations", description = "Test classes options")
 public final class WithAnnotationsCommand extends TestClassesDiscoverer {
 
-    @Option(names = "--include", split = ",", description = "List of testClasses with annotations to include")
+    @Option(
+            names = "--include",
+            split = ",",
+            description = "List of testClasses with annotations to include",
+            defaultValue = "")
     private List<String> includedAnnotations;
-
-    @Option(names = "--exclude", split = ",", description = "List of testClasses with annotations to exclude")
-    private List<String> excludedAnnotations;
 
     @Override
     protected Filter<?> getFilter() {
         List<? extends Class<? extends Annotation>> includedClasses = asAnnotationClasses(includedAnnotations);
-        List<? extends Class<? extends Annotation>> excludedClasses = asAnnotationClasses(excludedAnnotations);
         return new PostDiscoveryFilter() {
             @Override
             public FilterResult apply(TestDescriptor testDescriptor) {
@@ -47,10 +47,7 @@ public final class WithAnnotationsCommand extends TestClassesDiscoverer {
                         .getSource()
                         .map(TestClassesDiscoverer::getTestClassFromSource)
                         .map(testClass -> {
-                            if (hasAnyClassAnnotations(testClass, excludedClasses)) {
-                                return FilterResult.excluded(
-                                        String.format("%s has an excluded annotation", testDescriptor));
-                            } else if (hasAnyClassAnnotations(testClass, includedClasses)) {
+                            if (hasAnyClassAnnotations(testClass, includedClasses)) {
                                 return FilterResult.included(
                                         String.format("%s has an allowlisted annotation", testDescriptor));
                             }

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -178,7 +178,7 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
                                             "withAnnotations",
                                             "--include",
                                             "com.palantir.gradle.testing.junit.GradlePluginTests",
-                                            "--exclude",
+                                            "--include",
                                             "com.palantir.gradle.testing.junit.DisabledConfigurationCache"));
                         });
 

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -177,8 +177,6 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
                                     .addAll(List.of(
                                             "withAnnotations",
                                             "--include",
-                                            "com.palantir.gradle.testing.junit.GradlePluginTests",
-                                            "--include",
                                             "com.palantir.gradle.testing.junit.DisabledConfigurationCache"));
                         });
 

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -273,7 +273,7 @@ class PluginTestingJunitPluginTest {
         gradle.withArgs("discoverGradlePluginTestsWithDisabledConfigurationCache")
                 .buildsSuccessfully();
         assertThat(readTestClassesPaths(rootProject, "java"))
-                .containsExactlyInAnyOrder("src/test/java/test/GradlePluginTestClass.java");
+                .containsExactlyInAnyOrder("src/test/java/test/NoConfigCacheGradlePluginTestClass.java");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
`discoverGradlePluginTestsWithDisabledConfigurationCache` needs to check for the `@DisabledConfigurationCache` annotation only.
==COMMIT_MSG==
Fix `discoverGradlePluginTestsWithDisabledConfigurationCache`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

