### PR TITLE
handle multiple buildscripts when repositioning plugins block

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/Plugins.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/Plugins.java
@@ -16,7 +16,7 @@
 
 package com.palantir.gradle.testing.files.gradle;
 
-import java.util.ArrayList;
+import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -89,29 +89,27 @@ public final class Plugins {
     }
 
     private static String repositionPluginsBlockWithContent(String textWithoutPluginsBlock, String pluginsBlock) {
-        // Extract all buildscript blocks and collect remaining content
-        List<String> buildscriptBlocks = new ArrayList<>();
-        String remainingText = textWithoutPluginsBlock;
+        // Find all buildscript block ranges in a single pass
+        List<int[]> ranges = BUILDSCRIPT_PATTERN
+                .matcher(textWithoutPluginsBlock)
+                .results()
+                .map(match -> findMatchingBrace(textWithoutPluginsBlock, match.end() - 1)
+                        .map(endIndex -> new int[] {match.start(), endIndex}))
+                .takeWhile(Optional::isPresent)
+                .flatMap(Optional::stream)
+                .toList();
 
-        for (Matcher matcher = BUILDSCRIPT_PATTERN.matcher(remainingText);
-                matcher.find();
-                matcher = BUILDSCRIPT_PATTERN.matcher(remainingText)) {
+        // Extract buildscript blocks
+        String buildscripts = ranges.stream()
+                .map(range -> textWithoutPluginsBlock.substring(range[0], range[1]))
+                .collect(Collectors.joining("\n"));
 
-            int startIndex = matcher.start();
-            int openBraceIndex = matcher.end() - 1;
-
-            // Find matching closing brace
-            Optional<Integer> endIndex = findMatchingBrace(remainingText, openBraceIndex);
-            if (endIndex.isEmpty()) {
-                break;
-            }
-
-            buildscriptBlocks.add(remainingText.substring(startIndex, endIndex.get()));
-            remainingText = remainingText.substring(0, startIndex) + remainingText.substring(endIndex.get());
-        }
-
-        // Reconstruct: buildscripts + plugins + remaining content
-        String buildscripts = String.join("\n", buildscriptBlocks);
+        // Build remaining text by subtracting ranges (reverse order to preserve indices)
+        String remainingText = Lists.reverse(ranges).stream()
+                .reduce(
+                        textWithoutPluginsBlock,
+                        (text, range) -> text.substring(0, range[0]) + text.substring(range[1]),
+                        (_a, _b) -> _a);
 
         String cleanedRemaining = remainingText.replaceFirst("^\\n+", "");
 
@@ -157,6 +155,8 @@ public final class Plugins {
 
         return repositionPluginsBlockWithContent(textWithoutPluginsBlock, pluginsBlock);
     }
+
+    private record Range(int start, int end) {}
 
     private static Optional<Integer> findMatchingBrace(String text, int openBraceIndex) {
         int depth = 1;

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/Plugins.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/Plugins.java
@@ -156,8 +156,6 @@ public final class Plugins {
         return repositionPluginsBlockWithContent(textWithoutPluginsBlock, pluginsBlock);
     }
 
-    private record Range(int start, int end) {}
-
     private static Optional<Integer> findMatchingBrace(String text, int openBraceIndex) {
         int depth = 1;
         for (int i = openBraceIndex + 1; i < text.length(); i++) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/Plugins.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/Plugins.java
@@ -16,9 +16,9 @@
 
 package com.palantir.gradle.testing.files.gradle;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -89,16 +89,37 @@ public final class Plugins {
     }
 
     private static String repositionPluginsBlockWithContent(String textWithoutPluginsBlock, String pluginsBlock) {
-        OptionalInt buildscriptEnd = findBuildScriptBlockEnd(textWithoutPluginsBlock);
+        // Extract all buildscript blocks and collect remaining content
+        List<String> buildscriptBlocks = new ArrayList<>();
+        String remainingText = textWithoutPluginsBlock;
 
-        // plugins block must go after buildscript and above all else
-        if (buildscriptEnd.isPresent()) {
-            String suffix =
-                    textWithoutPluginsBlock.substring(buildscriptEnd.getAsInt()).replaceFirst("^\n", "");
-            return textWithoutPluginsBlock.substring(0, buildscriptEnd.getAsInt()) + "\n" + pluginsBlock + suffix;
+        for (Matcher matcher = BUILDSCRIPT_PATTERN.matcher(remainingText);
+                matcher.find();
+                matcher = BUILDSCRIPT_PATTERN.matcher(remainingText)) {
+
+            int startIndex = matcher.start();
+            int openBraceIndex = matcher.end() - 1;
+
+            // Find matching closing brace
+            Optional<Integer> endIndex = findMatchingBrace(remainingText, openBraceIndex);
+            if (endIndex.isEmpty()) {
+                break;
+            }
+
+            buildscriptBlocks.add(remainingText.substring(startIndex, endIndex.get()));
+            remainingText = remainingText.substring(0, startIndex) + remainingText.substring(endIndex.get());
         }
 
-        return pluginsBlock + textWithoutPluginsBlock;
+        // Reconstruct: buildscripts + plugins + remaining content
+        String buildscripts = String.join("\n", buildscriptBlocks);
+
+        String cleanedRemaining = remainingText.replaceFirst("^\\n+", "");
+
+        if (buildscripts.isEmpty()) {
+            return pluginsBlock + cleanedRemaining;
+        }
+
+        return buildscripts + "\n" + pluginsBlock + cleanedRemaining;
     }
 
     /**
@@ -137,14 +158,7 @@ public final class Plugins {
         return repositionPluginsBlockWithContent(textWithoutPluginsBlock, pluginsBlock);
     }
 
-    private static OptionalInt findBuildScriptBlockEnd(String text) {
-        Matcher matcher = BUILDSCRIPT_PATTERN.matcher(text);
-        if (!matcher.find()) {
-            return OptionalInt.empty();
-        }
-        int openBraceIndex = matcher.end() - 1; // position of '{'
-
-        // Match braces
+    private static Optional<Integer> findMatchingBrace(String text, int openBraceIndex) {
         int depth = 1;
         for (int i = openBraceIndex + 1; i < text.length(); i++) {
             char ch = text.charAt(i);
@@ -154,9 +168,9 @@ public final class Plugins {
                 depth--;
             }
             if (depth == 0) {
-                return OptionalInt.of(i + 1); // Return index after closing '}'
+                return Optional.of(i + 1);
             }
         }
-        return OptionalInt.empty();
+        return Optional.empty();
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/PluginsUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/PluginsUsagesTest.java
@@ -247,4 +247,94 @@ class PluginsUsagesTest {
             }
             """);
     }
+
+    @Test
+    void plugins_block_is_positioned_after_all_buildscripts(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("""
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            repositories {
+                mavenCentral()
+            }
+            """);
+
+        rootProject.buildGradle().plugins().add("java");
+
+        rootProject.buildGradle().append("""
+            buildscript {
+                repositories {
+                    mavenLocal()
+                }
+            }
+            repositories {
+                mavenLocal()
+            }
+            """);
+
+        rootProject.buildGradle().assertThat().hasContent("""
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            buildscript {
+                repositories {
+                    mavenLocal()
+                }
+            }
+            plugins {
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+
+            repositories {
+                mavenLocal()
+            }
+            """);
+    }
+
+    @Test
+    void adding_plugin_to_file_with_multiple_existing_buildscripts(RootProject rootProject) {
+        rootProject.buildGradle().overwrite("""
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            buildscript {
+                dependencies {
+                    classpath 'com.example:plugin:1.0'
+                }
+            }
+            repositories {
+                mavenCentral()
+            }
+            """);
+
+        rootProject.buildGradle().plugins().add("java");
+
+        rootProject.buildGradle().assertThat().hasContent("""
+            buildscript {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            buildscript {
+                dependencies {
+                    classpath 'com.example:plugin:1.0'
+                }
+            }
+            plugins {
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            """);
+    }
 }


### PR DESCRIPTION
## Before this PR

We could only handle a single buildscript block. When positioning the plugins block, we would place it after the first buildscript found. This was problematic because:

1. Multiple buildscript blocks are valid Gradle - Gradle allows multiple buildscript blocks in a single build file, and they are evaluated in order
2. Common test patterns broke - A user might have a helper like standardBuildfile(rootProject) that sets up common configuration including a buildscript, then later .append("""buildscript { ... }""") to add test-specific classpath dependencies
3. Workaround was manual editing - Previously, users had to manually use .edit() to merge multiple buildscript blocks into one to avoid the plugins block being incorrectly positioned between them

## After this PR

Now we correctly handle multiple buildscript blocks by:
- Extracting all buildscript blocks from the file
- Moving them all to the top of the file
- Positioning the plugins block after all buildscripts
- Placing the remaining content after the plugins block

This means patterns like this now work correctly:

```java
standardBuildfile(rootProject).append("""
    buildscript {
        dependencies {
            classpath 'com.example:plugin:1.0'
        }
    }
    """);
rootProject.buildGradle().plugins().add("java");
```

The result will have both buildscript blocks at the top, followed by the plugins block.

==COMMIT_MSG==
Handle multiple buildscript blocks when positioning plugins

Previously, adding plugins to a file with multiple buildscript blocks
would incorrectly position the plugins block after only the first
buildscript. Now all buildscript blocks are collected and moved to the
top, with the plugins block positioned after all of them.
==COMMIT_MSG==

## Possible downsides?
