### PR TITLE
tune instructions

### DIFF
--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -72,8 +72,27 @@ These comments should be copied over to the new test files as they are created t
     - `.build()` → `.buildsSuccessfully()`
     - `.buildAndFail()` → `.buildsWithFailure()`
     - `with('task').build()` → `gradle.withArgs('task').buildsSuccessfully()`
-- If you need to parse a POM / xml file use `jackson` with `records`
 - When an external plugin is used ensure the correct `gradlePluginForTesting` configuration is added to the projects `build.gradle` file
+- When migrating ONLY use the `standardBuildFile` pattern if it was used in the old groovy test
+- If you need to parse a POM / xml file use `jackson` with `records` e.g.
+```java
+@JsonIgnoreProperties(ignoreUnknown = true)
+record PomProject(
+    @JacksonXmlProperty(localName = "dependencies") PomDependencies dependencies) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record PomDependencies(
+            @JacksonXmlElementWrapper(useWrapping = false) @JacksonXmlProperty(localName = "dependency")
+            List<PomDependency> dependency) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record PomDependency(
+            @JacksonXmlProperty(localName = "groupId") String groupId,
+            @JacksonXmlProperty(localName = "artifactId") String artifactId,
+            @JacksonXmlProperty(localName = "version") String version,
+            @JacksonXmlProperty(localName = "scope") String scope) {}
+}
+```
 
 
 # File Manipulation Instructions

--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -72,7 +72,7 @@ These comments should be copied over to the new test files as they are created t
     - `.build()` → `.buildsSuccessfully()`
     - `.buildAndFail()` → `.buildsWithFailure()`
     - `with('task').build()` → `gradle.withArgs('task').buildsSuccessfully()`
-- File you are parsing a POM / xml file use jackson with records 
+- If you need to parse a POM / xml file use `jackson` with `records`
 - When an external plugin is used ensure the correct `gradlePluginForTesting` configuration is added to the projects `build.gradle` file
 
 

--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -72,6 +72,8 @@ These comments should be copied over to the new test files as they are created t
     - `.build()` → `.buildsSuccessfully()`
     - `.buildAndFail()` → `.buildsWithFailure()`
     - `with('task').build()` → `gradle.withArgs('task').buildsSuccessfully()`
+- File you are parsing a POM / xml file use jackson with records 
+- When an external plugin is used ensure the correct `gradlePluginForTesting` configuration is added to the projects `build.gradle` file
 
 
 # File Manipulation Instructions

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -297,6 +297,9 @@ void create_custom_gradle_files(RootProject project) {
 ```
 
 Or use a helper method to setup a standard build file used across multiple tests:
+
+> Note: only use this pattern if you cannot setup the build gradle file in a `@BeforeEach` / `@BeforeAll`
+
 ```java
 import com.palantir.gradle.testing.files.gradle.GradleFile;
 


### PR DESCRIPTION
## Before this PR
AI was too keen on creating `standardBuildFile` and was not using jackson / records for pom parsing. Not always using `gradlePluginForTesting`
## After this PR
Now we point these out to the AI more explicitly in the instructions 
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

