### PR TITLE
fix errorprone bug in `findVariableInitializer` 

### DIFF
--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradlePluginTestHelpers.java
@@ -59,6 +59,7 @@ public final class GradlePluginTestHelpers {
                 .map(TreePath::getLeaf)
                 .select(VariableTree.class)
                 .map(VariableTree::getInitializer)
+                .nonNull()
                 .findFirst();
     }
 

--- a/gradle-plugin-testing-error-prone/src/test/java/com/palantir/gradle/testing/errorprone/GradleTestStringFormattingTest.java
+++ b/gradle-plugin-testing-error-prone/src/test/java/com/palantir/gradle/testing/errorprone/GradleTestStringFormattingTest.java
@@ -220,6 +220,21 @@ class GradleTestStringFormattingTest {
     }
 
     @Test
+    void allow_method_parameter_as_argument() {
+        test("""
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import com.palantir.gradle.testing.files.ProjectFile;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(ProjectFile file, String extraContent) {
+                    file.appendLine(extraContent);
+                }
+            }
+            """);
+    }
+
+    @Test
     void allow_formatted_strings_when_no_format_method_overload_exists() {
         test("""
             import com.palantir.gradle.testing.junit.GradlePluginTests;


### PR DESCRIPTION
## Before this PR

The `findVariableInitializer` method in `GradlePluginTestHelpers` could cause a NullPointerException when processing variables without initializers (e.g., method parameters
like `void test(ProjectFile file, String extraContent))`.

When `VariableTree::getInitializer` returns null for such variables, the stream's `findFirst()` would propagate the null, causing ErrorProne to crash with an unhandled
exception.

## After this PR

Added `.nonNull()` filter before `findFirst()` in `findVariableInitializer` to gracefully handle variables without initialisers. The method now correctly returns
`Optional.empty()` instead of crashing.

Added a test case to verify that method parameters used as arguments to library methods are handled correctly.

Possible downsides?

None - this is a defensive fix that makes the code more robust without changing its intended.