### PR TITLE
Wrap `@GradlePluginTests` TestKit build outputs in nice color-coded boxes

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvocation.java
@@ -44,8 +44,7 @@ public final class DefaultGradleInvocation implements GradleInvocation {
             return new InvocationResult(result);
         } catch (UnexpectedBuildFailure e) {
             printFormattedOutput(false);
-            // Don't rethrow e, as it needlessly prints the inner build output again
-            throw new RuntimeException("Expected build to be successful: " + outputTitle);
+            throw e;
         }
     }
 
@@ -57,8 +56,7 @@ public final class DefaultGradleInvocation implements GradleInvocation {
             return new InvocationResult(result);
         } catch (UnexpectedBuildSuccess e) {
             printFormattedOutput(true);
-            // Don't rethrow e, as it needlessly prints the inner build output again
-            throw new RuntimeException("Expected build to fail: " + outputTitle);
+            throw e;
         }
     }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvocation.java
@@ -16,23 +16,58 @@
 
 package com.palantir.gradle.testing.execution;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.gradle.testkit.runner.UnexpectedBuildSuccess;
 
 public final class DefaultGradleInvocation implements GradleInvocation {
 
     private final GradleRunner gradleRunner;
+    private final ByteArrayOutputStream capturedOutput;
+    private final String outputTitle;
 
-    public DefaultGradleInvocation(GradleRunner gradleRunner) {
+    public DefaultGradleInvocation(
+            GradleRunner gradleRunner, String outputTitle, ByteArrayOutputStream capturedOutput) {
         this.gradleRunner = gradleRunner;
+        this.outputTitle = outputTitle;
+        this.capturedOutput = capturedOutput;
     }
 
     @Override
     public InvocationResult buildsSuccessfully() {
-        return new InvocationResult(gradleRunner.build());
+        try {
+            BuildResult result = gradleRunner.build();
+            printFormattedOutput(true);
+            return new InvocationResult(result);
+        } catch (UnexpectedBuildFailure e) {
+            printFormattedOutput(false);
+            // Don't rethrow e, as it needlessly prints the inner build output again
+            throw new RuntimeException("Expected build to be successful: " + outputTitle);
+        }
     }
 
     @Override
     public InvocationResult buildsWithFailure() {
-        return new InvocationResult(gradleRunner.buildAndFail());
+        try {
+            BuildResult result = gradleRunner.buildAndFail();
+            printFormattedOutput(false);
+            return new InvocationResult(result);
+        } catch (UnexpectedBuildSuccess e) {
+            printFormattedOutput(true);
+            // Don't rethrow e, as it needlessly prints the inner build output again
+            throw new RuntimeException("Expected build to fail: " + outputTitle);
+        }
+    }
+
+    private void printFormattedOutput(boolean success) {
+        String output = capturedOutput.toString(StandardCharsets.UTF_8);
+        String formatted = success
+                ? OutputBoxFormatter.formatSuccess(outputTitle, output)
+                : OutputBoxFormatter.formatFailure(outputTitle, output);
+        // CHECKSTYLE.OFF: RegexpSinglelineJava
+        System.out.println("\n" + formatted + "\n");
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvocation.java
@@ -60,12 +60,12 @@ public final class DefaultGradleInvocation implements GradleInvocation {
         }
     }
 
+    @SuppressWarnings("checkstyle:RegexpSinglelineJava")
     private void printFormattedOutput(boolean success) {
         String output = capturedOutput.toString(StandardCharsets.UTF_8);
         String formatted = success
                 ? OutputBoxFormatter.formatSuccess(outputTitle, output)
                 : OutputBoxFormatter.formatFailure(outputTitle, output);
-        // CHECKSTYLE.OFF: RegexpSinglelineJava
         System.out.println("\n" + formatted + "\n");
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -19,7 +19,12 @@ package com.palantir.gradle.testing.execution;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.List;
 import org.gradle.testkit.runner.GradleRunner;
 
 record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) implements GradleInvoker {
@@ -28,10 +33,14 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
 
     @Override
     public GradleInvocation with(Options options) {
+        ByteArrayOutputStream capturedOutput = new ByteArrayOutputStream();
+        Writer captureWriter = new OutputStreamWriter(capturedOutput, StandardCharsets.UTF_8);
+
         GradleRunner runner = GradleRunner.create()
                 .withProjectDir(rootProjectDir.toFile())
                 .withDebug(GradleInvoker.shouldRunInTestkitDebugMode())
-                .forwardOutput()
+                .forwardStdOutput(captureWriter)
+                .forwardStdError(captureWriter)
                 .withGradleVersion(gradleVersion.version())
                 .withPluginClasspath()
                 .withArguments(ImmutableList.<String>builder()
@@ -44,6 +53,15 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
                         .build());
         options.customGradleUserHome().ifPresent(gradleUserHome -> runner.withTestKitDir(gradleUserHome.toFile()));
 
-        return new DefaultGradleInvocation(runner);
+        String title = buildTitle(options.args());
+        return new DefaultGradleInvocation(runner, title, capturedOutput);
+    }
+
+    private String buildTitle(List<String> args) {
+        StringBuilder title = new StringBuilder();
+        title.append("gradle ");
+        title.append(String.join(" ", args));
+        title.append(" [Gradle ").append(gradleVersion.version()).append("]");
+        return title.toString();
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/OutputBoxFormatter.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/OutputBoxFormatter.java
@@ -1,0 +1,145 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.execution;
+
+import java.util.Arrays;
+
+/**
+ * Formats output text within a colored box border for improved visual distinction.
+ * Useful for displaying inner Gradle build output within test execution logs.
+ */
+public final class OutputBoxFormatter {
+
+    private static final String ANSI_RESET = "\u001B[0m";
+    private static final String ANSI_RED = "\u001B[31m";
+    private static final String ANSI_GREEN = "\u001B[32m";
+    private static final String ANSI_BRIGHT_WHITE = "\u001B[97m";
+
+    // Box drawing characters (Unicode)
+    private static final char TOP_LEFT = '╔';
+    private static final char TOP_RIGHT = '╗';
+    private static final char BOTTOM_LEFT = '╚';
+    private static final char BOTTOM_RIGHT = '╝';
+    private static final char HORIZONTAL = '═';
+    private static final char VERTICAL = '║';
+    private static final char LEFT_T = '╠';
+    private static final char RIGHT_T = '╣';
+
+    private static final int PADDING = 1; // spaces on each side of content
+
+    private OutputBoxFormatter() {
+        // utility class
+    }
+
+    /**
+     * Formats the given content in a green-bordered box with the specified title.
+     *
+     * @param title the title to display in the header
+     * @param content the content to box
+     * @return the formatted output with green borders
+     */
+    public static String formatSuccess(String title, String content) {
+        return format(title, content, ANSI_GREEN);
+    }
+
+    /**
+     * Formats the given content in a red-bordered box with the specified title.
+     *
+     * @param title the title to display in the header
+     * @param content the content to box
+     * @return the formatted output with red borders
+     */
+    public static String formatFailure(String title, String content) {
+        return format(title, content, ANSI_RED);
+    }
+
+    private static String format(String title, String content, String color) {
+        String[] lines = content.split("\\r?\\n");
+
+        // Calculate the width based on content, but with reasonable bounds
+        int contentWidth = calculateWidth(title, lines);
+
+        StringBuilder result = new StringBuilder();
+
+        // Top border with title
+        result.append(color);
+        result.append(TOP_LEFT);
+        String header = " " + title + " ";
+        result.append(header);
+        result.append(repeatChar(HORIZONTAL, contentWidth - header.length()));
+        result.append(TOP_RIGHT);
+        result.append(ANSI_RESET);
+        result.append('\n');
+
+        // Separator line
+        result.append(color);
+        result.append(LEFT_T);
+        result.append(repeatChar(HORIZONTAL, contentWidth));
+        result.append(RIGHT_T);
+        result.append(ANSI_RESET);
+        result.append('\n');
+
+        // Content lines - no truncation, pad to box width
+        for (String line : lines) {
+            result.append(color);
+            result.append(VERTICAL);
+            result.append(ANSI_RESET);
+            result.append(' '); // left padding
+
+            result.append(ANSI_BRIGHT_WHITE);
+            result.append(line);
+            result.append(ANSI_RESET);
+            // Pad to match box width
+            result.append(repeatChar(' ', contentWidth - (2 * PADDING) - line.length()));
+
+            result.append(' '); // right padding
+            result.append(color);
+            result.append(VERTICAL);
+            result.append(ANSI_RESET);
+            result.append('\n');
+        }
+
+        // Bottom border
+        result.append(color);
+        result.append(BOTTOM_LEFT);
+        result.append(repeatChar(HORIZONTAL, contentWidth));
+        result.append(BOTTOM_RIGHT);
+        result.append(ANSI_RESET);
+
+        return result.toString();
+    }
+
+    private static int calculateWidth(String title, String[] lines) {
+        // Find the longest line
+        int maxLineLength = Arrays.stream(lines).mapToInt(String::length).max().orElse(0);
+
+        // Account for title with checkmark/cross prefix
+        int titleLength = title.length() + 4; // " ✓ " or " ✗ " + title + " "
+
+        // Use the larger of title or content, with padding
+        return Math.max(titleLength, maxLineLength + (2 * PADDING));
+    }
+
+    private static String repeatChar(char ch, int count) {
+        if (count <= 0) {
+            return "";
+        }
+        char[] chars = new char[count];
+        Arrays.fill(chars, ch);
+        return new String(chars);
+    }
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/OutputBoxFormatter.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/OutputBoxFormatter.java
@@ -17,6 +17,8 @@
 package com.palantir.gradle.testing.execution;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Formats output text within a colored box border for improved visual distinction.
@@ -41,34 +43,26 @@ public final class OutputBoxFormatter {
 
     private static final int PADDING = 1; // spaces on each side of content
 
-    private OutputBoxFormatter() {
-        // utility class
-    }
+    private OutputBoxFormatter() {}
 
-    /**
-     * Formats the given content in a green-bordered box with the specified title.
-     *
-     * @param title the title to display in the header
-     * @param content the content to box
-     * @return the formatted output with green borders
-     */
     public static String formatSuccess(String title, String content) {
-        return format(title, content, ANSI_GREEN);
+        if (System.getenv("CI") == null) {
+            return format(title, content, Optional.of(ANSI_GREEN));
+        } else {
+            return format("SUCCESS: " + title, content, Optional.empty());
+        }
     }
 
-    /**
-     * Formats the given content in a red-bordered box with the specified title.
-     *
-     * @param title the title to display in the header
-     * @param content the content to box
-     * @return the formatted output with red borders
-     */
     public static String formatFailure(String title, String content) {
-        return format(title, content, ANSI_RED);
+        if (System.getenv("CI") == null) {
+            return format(title, content, Optional.of(ANSI_RED));
+        } else {
+            return format("FAILURE: " + title, content, Optional.empty());
+        }
     }
 
-    private static String format(String title, String content, String color) {
-        String[] lines = content.split("\\r?\\n");
+    private static String format(String title, String content, Optional<String> color) {
+        List<String> lines = content.lines().toList();
 
         // Calculate the width based on content, but with reasonable bounds
         int contentWidth = calculateWidth(title, lines);
@@ -76,56 +70,57 @@ public final class OutputBoxFormatter {
         StringBuilder result = new StringBuilder();
 
         // Top border with title
-        result.append(color);
+        color.ifPresent(result::append);
         result.append(TOP_LEFT);
         String header = " " + title + " ";
         result.append(header);
         result.append(repeatChar(HORIZONTAL, contentWidth - header.length()));
         result.append(TOP_RIGHT);
-        result.append(ANSI_RESET);
+        color.ifPresent(unused -> result.append(ANSI_RESET));
         result.append('\n');
 
         // Separator line
-        result.append(color);
+        color.ifPresent(result::append);
         result.append(LEFT_T);
         result.append(repeatChar(HORIZONTAL, contentWidth));
         result.append(RIGHT_T);
-        result.append(ANSI_RESET);
+        color.ifPresent(unused -> result.append(ANSI_RESET));
         result.append('\n');
 
         // Content lines - no truncation, pad to box width
         for (String line : lines) {
-            result.append(color);
+            color.ifPresent(result::append);
             result.append(VERTICAL);
-            result.append(ANSI_RESET);
+            color.ifPresent(unused -> result.append(ANSI_RESET));
             result.append(' '); // left padding
 
-            result.append(ANSI_BRIGHT_WHITE);
+            color.ifPresent(result::append);
+            color.ifPresent(unused -> result.append(ANSI_BRIGHT_WHITE));
             result.append(line);
-            result.append(ANSI_RESET);
+            color.ifPresent(unused -> result.append(ANSI_RESET));
             // Pad to match box width
             result.append(repeatChar(' ', contentWidth - (2 * PADDING) - line.length()));
 
             result.append(' '); // right padding
-            result.append(color);
+            color.ifPresent(result::append);
             result.append(VERTICAL);
-            result.append(ANSI_RESET);
+            color.ifPresent(unused -> result.append(ANSI_RESET));
             result.append('\n');
         }
 
         // Bottom border
-        result.append(color);
+        color.ifPresent(result::append);
         result.append(BOTTOM_LEFT);
         result.append(repeatChar(HORIZONTAL, contentWidth));
         result.append(BOTTOM_RIGHT);
-        result.append(ANSI_RESET);
+        color.ifPresent(unused -> result.append(ANSI_RESET));
 
         return result.toString();
     }
 
-    private static int calculateWidth(String title, String[] lines) {
+    private static int calculateWidth(String title, List<String> lines) {
         // Find the longest line
-        int maxLineLength = Arrays.stream(lines).mapToInt(String::length).max().orElse(0);
+        int maxLineLength = lines.stream().mapToInt(String::length).max().orElse(0);
 
         // Account for title with checkmark/cross prefix
         int titleLength = title.length() + 4; // " ✓ " or " ✗ " + title + " "


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

In a `@GradlePluginTest`, the build outputs of the 1. test driver "outer" build 2. multiple "inner" testkit builds[^1] are all mangled together. 

#### Example of success
<img width="1654" height="1153" alt="Screenshot 2025-12-15 at 14 32 38" src="https://github.com/user-attachments/assets/0bead065-68fc-475a-be71-32130d21b5a1" />


#### Example of failure
<img width="1654" height="1112" alt="Screenshot 2025-12-15 at 14 31 42" src="https://github.com/user-attachments/assets/6899daa8-8af1-4e6b-a611-6c01b99f908e" />




## After this PR
<!-- User-facing outcomes this PR delivers go below -->

#### Example of success

<img width="1654" height="854" alt="Screenshot 2025-12-15 at 14 23 21" src="https://github.com/user-attachments/assets/7d50c335-48c9-4428-b7d4-69bb64d421ad" />

#### Example of failure

<img width="1964" height="1156" alt="Screenshot 2025-12-15 at 14 22 14" src="https://github.com/user-attachments/assets/c933012a-51fe-40bc-8ea0-894ac211342a" />

==COMMIT_MSG==
Wrap `@GradlePluginTests` TestKit build outputs in nice color-coded boxes
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

There's a concern that this would  interfere with Intellij's diff formatter. The diff formatter only triggers on `assertEquals` ([source](https://stackoverflow.com/a/10945655)), and people are not asserting equality on entire build outputs. So it should be fine.

Also, ANSI codes will not be added to the output if the `CI` environment variable is set. This way we don't clobber CI with ANSI codes

[^1]: e.g. when testing for configuration cache compatibility, two builds are run, with the second time being a `--dry-run`
