### PR TITLE
Use value for name of DisabledConfigurationCache element

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -555,14 +555,14 @@ For tests or test classes that are incompatible with configuration cache, use th
 ```java
 // Disable configuration cache for a specific test method
 @Test
-@DisabledConfigurationCache(reason="task abc is incompatible with configuration cache")
+@DisabledConfigurationCache("task abc is incompatible with configuration cache")
 void incompatible_configuration_cache_build(GradleInvoker gradle, RootProject project) {
 ```
 Or
 ```java
 // Disable for an entire test class
 @GradlePluginTests
-@DisabledConfigurationCache(reason="tasks abc, xyz are incompatible with configuration cache")
+@DisabledConfigurationCache("tasks abc, xyz are incompatible with configuration cache")
 class PluginIncompatibleWithConfigCache {
 ```
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/DisabledConfigurationCache.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/DisabledConfigurationCache.java
@@ -37,5 +37,5 @@ public @interface DisabledConfigurationCache {
      * The reason why the configuration cache is disabled.
      * @return the reason as a string
      */
-    String reason() default "";
+    String value() default "";
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
@@ -86,7 +86,7 @@ class ConfigurationCacheTests {
     }
 
     @Test
-    @DisabledConfigurationCache(reason = "testing method level annotation")
+    @DisabledConfigurationCache("testing method level annotation")
     void configuration_cache_is_disabled(GradleInvoker invoker, RootProject rootProject) {
         setUpConfigurationCacheTask(rootProject);
 

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/DisabledConfigurationCacheFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/DisabledConfigurationCacheFixtureTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 // This is a test fixture, not a test.
 @GradlePluginTests
-@DisabledConfigurationCache(reason = "testing class level annotation")
+@DisabledConfigurationCache("testing class level annotation")
 public class DisabledConfigurationCacheFixtureTest {
 
     @Test


### PR DESCRIPTION
This allows for the shorthand version and matches the design of similar annotations like JUnit5's `@Disabled`.