### PR TITLE
Add `GradleVersion` parameter injection for conditional test skipping

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -101,6 +101,7 @@ Tests can request these parameters in any order:
 - **`RootProject`** - Gradle root project that will always be named "root". To use a different project name, call `rootProject.settingsGradle().rootProjectName("custom-name")`
 - **`SubProject`** - Gradle subproject for the root project. The parameter name will be used as the project name exactly. For example, `SubProject apiService` creates a subproject named `apiService`
 - **`MavenRepo`** - Maven repository for publishing test artifacts. See [Maven Repository Testing](#maven-repository-testing)
+- **`GradleVersion`** - The Gradle version for the current test invocation. Useful for conditionally skipping tests with `Assumptions`. See [Skipping Tests for Specific Versions](#skipping-tests-for-specific-versions)
 
 These parameters can be used in the constructor for a test class or in `@Test`, `@BeforeEach`, `@AfterEach`, `@BeforeAll`, or `@AfterAll` methods.
 
@@ -161,6 +162,27 @@ class CompatibilityTest {
 ```
 
 The versions from `@AdditionalGradleVersions` are merged with the globally configured versions. Duplicate versions are automatically deduplicated.
+
+#### Skipping Tests for Specific Versions
+
+Inject `GradleVersion` as a test parameter to conditionally skip tests using JUnit's `Assumptions`:
+
+```java
+import com.palantir.gradle.testing.execution.GradleVersion;
+import org.junit.jupiter.api.Assumptions;
+
+@GradlePluginTests
+class VersionSpecificTest {
+    @Test
+    void feature_only_available_in_gradle_8(GradleInvoker gradle, RootProject project, GradleVersion gradleVersion) {
+        Assumptions.assumeTrue(
+                gradleVersion.version().startsWith("8."),
+                "This feature requires Gradle 8.x");
+
+        // Test code that only runs on Gradle 8.x
+    }
+}
+```
 
 ## File Operations
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/GradleVersionParameterResolver.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/GradleVersionParameterResolver.java
@@ -1,0 +1,32 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.junit;
+
+import com.palantir.gradle.testing.execution.GradleVersion;
+import java.util.Optional;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+
+final class GradleVersionParameterResolver implements TerseParameterResolver {
+    @Override
+    public Optional<Object> parameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+        if (parameterContext.getParameter().getType().equals(GradleVersion.class)) {
+            return Optional.of(GradleVersionStore.gradleVersion(extensionContext));
+        }
+        return Optional.empty();
+    }
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/GradleVersioningClassTemplate.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/GradleVersioningClassTemplate.java
@@ -75,7 +75,8 @@ final class GradleVersioningClassTemplate implements ClassTemplateInvocationCont
             return List.of(
                     new GradleInvokerParameterResolver(),
                     new GradleProjectParameterResolver(),
-                    new MavenRepoParameterResolver());
+                    new MavenRepoParameterResolver(),
+                    new GradleVersionParameterResolver());
         }
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/GradleVersionParameterTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/GradleVersionParameterTest.java
@@ -1,0 +1,80 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.ete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.example.GradleVersionAssumptionFixtureTest;
+import com.palantir.example.GradleVersionParameterFixtureTest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+final class GradleVersionParameterTest {
+    @Test
+    void gradle_version_is_injected_as_test_parameter() {
+        EngineExecutionResults executionResults = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(GradleVersionParameterFixtureTest.class))
+                .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.14.3")
+                .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .execute();
+
+        List<Event> finished = executionResults.testEvents().finished().stream().toList();
+
+        assertThat(finished).hasSize(2);
+
+        assertThatTestReceivedGradleVersion(finished.get(0), "7.6.5");
+        assertThatTestReceivedGradleVersion(finished.get(1), "8.14.3");
+    }
+
+    @Test
+    void gradle_version_can_be_used_with_assumptions_to_skip_tests() {
+        EngineExecutionResults executionResults = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(GradleVersionAssumptionFixtureTest.class))
+                .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.14.3")
+                .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .execute();
+
+        List<Event> finished = executionResults.testEvents().finished().stream().toList();
+
+        assertThat(finished).hasSize(2);
+
+        // Gradle 7.6.5 should be skipped due to assumption
+        assertThat(finished.get(0).getPayload(TestExecutionResult.class)).hasValueSatisfying(result -> {
+            assertThat(result.getStatus()).isEqualTo(Status.ABORTED);
+        });
+
+        // Gradle 8.14.3 should run and fail (with our test exception)
+        assertThat(finished.get(1).getPayload(TestExecutionResult.class)).hasValueSatisfying(result -> {
+            assertThat(result.getStatus()).isEqualTo(Status.FAILED);
+            Assertions.assertThatTestFailureExceptionMessageContains(result, "Test ran on: 8.14.3");
+        });
+    }
+
+    private static void assertThatTestReceivedGradleVersion(Event event, String expectedVersion) {
+        assertThat(event.getPayload(TestExecutionResult.class)).hasValueSatisfying(testExecutionResult -> {
+            assertThat(testExecutionResult.getStatus()).isEqualTo(Status.FAILED);
+            Assertions.assertThatTestFailureExceptionMessageContains(
+                    testExecutionResult, "GradleVersion: " + expectedVersion);
+        });
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/GradleVersionParameterTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/GradleVersionParameterTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.example.GradleVersionAssumptionFixtureTest;
 import com.palantir.example.GradleVersionParameterFixtureTest;
+import com.palantir.example.GradleVersionWithAdditionalVersionsFixtureTest;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestExecutionResult;
@@ -67,6 +68,38 @@ final class GradleVersionParameterTest {
         assertThat(finished.get(1).getPayload(TestExecutionResult.class)).hasValueSatisfying(result -> {
             assertThat(result.getStatus()).isEqualTo(Status.FAILED);
             Assertions.assertThatTestFailureExceptionMessageContains(result, "Test ran on: 8.14.3");
+        });
+    }
+
+    @Test
+    void gradle_version_works_with_additional_gradle_versions_annotation() {
+        EngineExecutionResults executionResults = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(GradleVersionWithAdditionalVersionsFixtureTest.class))
+                // Base version from config, 8.0 and 8.5 from @AdditionalGradleVersions
+                .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5")
+                .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .execute();
+
+        List<Event> finished = executionResults.testEvents().finished().stream().toList();
+
+        // Should have 3 test runs: 7.6.5 from config + 8.0 and 8.5 from @AdditionalGradleVersions
+        assertThat(finished).hasSize(3);
+
+        // 7.6.5 should run (not skipped)
+        assertThat(finished.get(0).getPayload(TestExecutionResult.class)).hasValueSatisfying(result -> {
+            assertThat(result.getStatus()).isEqualTo(Status.FAILED);
+            Assertions.assertThatTestFailureExceptionMessageContains(result, "Test ran on: 7.6.5");
+        });
+
+        // 8.0 should be skipped due to assumption
+        assertThat(finished.get(1).getPayload(TestExecutionResult.class)).hasValueSatisfying(result -> {
+            assertThat(result.getStatus()).isEqualTo(Status.ABORTED);
+        });
+
+        // 8.5 should run (not skipped)
+        assertThat(finished.get(2).getPayload(TestExecutionResult.class)).hasValueSatisfying(result -> {
+            assertThat(result.getStatus()).isEqualTo(Status.FAILED);
+            Assertions.assertThatTestFailureExceptionMessageContains(result, "Test ran on: 8.5");
         });
     }
 

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/GradleVersionAssumptionFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/GradleVersionAssumptionFixtureTest.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example;
+
+import com.palantir.gradle.testing.execution.GradleVersion;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+public class GradleVersionAssumptionFixtureTest {
+    @Test
+    void test_skipped_on_gradle_7(GradleVersion gradleVersion) {
+        Assumptions.assumeTrue(!gradleVersion.version().startsWith("7."), "Skipping test on Gradle 7.x");
+        throw new RuntimeException("Test ran on: " + gradleVersion.version());
+    }
+}

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/GradleVersionParameterFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/GradleVersionParameterFixtureTest.java
@@ -1,0 +1,30 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example;
+
+import com.palantir.gradle.testing.execution.GradleVersion;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+public class GradleVersionParameterFixtureTest {
+    @Test
+    void test_receives_gradle_version(GradleVersion gradleVersion) {
+        // Throw the version so the test runner can verify it was injected correctly
+        throw new RuntimeException("GradleVersion: " + gradleVersion.version());
+    }
+}

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/GradleVersionWithAdditionalVersionsFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/GradleVersionWithAdditionalVersionsFixtureTest.java
@@ -1,0 +1,33 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example;
+
+import com.palantir.gradle.testing.execution.GradleVersion;
+import com.palantir.gradle.testing.junit.AdditionalGradleVersions;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+@AdditionalGradleVersions({"8.0", "8.5"})
+public class GradleVersionWithAdditionalVersionsFixtureTest {
+    @Test
+    void test_skips_additional_version(GradleVersion gradleVersion) {
+        Assumptions.assumeTrue(!gradleVersion.version().equals("8.0"), "Skipping on Gradle 8.0");
+        throw new RuntimeException("Test ran on: " + gradleVersion.version());
+    }
+}


### PR DESCRIPTION
## Before this PR

Tests had no way to access the current Gradle version being tested. This made it impossible to conditionally skip tests for specific versions using JUnit's Assumptions.

## After this PR

Tests can inject `GradleVersion` as a parameter to conditionally skip tests:
```java
@Test
void feature_only_in_gradle_8(GradleInvoker gradle, GradleVersion gradleVersion) {
    Assumptions.assumeTrue(gradleVersion.version().startsWith("8."), "Requires Gradle 8.x");
    // ...
}
```
==COMMIT_MSG==
Add `GradleVersion `parameter injection

Allows tests to inject `GradleVersion` as a parameter, enabling conditional
skipping via JUnit Assumptions based on the current Gradle version.
==COMMIT_MSG==

## Possible downsides?

None anticipated. This is purely additive - existing tests continue to work unchanged.

