### PR TITLE
Read gradle/gradle-test-versions.yml from the root dir, rather than project dir

### DIFF
--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -140,8 +140,18 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
                             .addAll(versionsFromConfig)
                             .addAll(versionsFromExtension)
                             .build();
+                    log.info(
+                            "PluginTestingPlugin Gradle versions from gradle/gradle-test-versions.yml: {}",
+                            versionsFromConfig);
+                    log.info(
+                            "PluginTestingPlugin Gradle versions from extensions (deprecated): {}",
+                            versionsFromExtension);
                     if (gradleTestVersions.isEmpty()) {
                         gradleTestVersions = Set.of(GradleVersion.current().getVersion());
+                        log.info(
+                                "PluginTestingPlugin using default Gradle version (both extension and config file are"
+                                        + " unset) {}",
+                                gradleTestVersions);
                     }
                     String versions = String.join(",", gradleTestVersions);
                     test.systemProperty(GradleTestVersions.TEST_GRADLE_VERSIONS_SYSTEM_PROPERTY, versions);
@@ -276,7 +286,7 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
 
     private Provider<Set<String>> readGradleTestingVersionsConfigFile() {
         RegularFile testVersionsConfigPath =
-                getProjectLayout().getProjectDirectory().file("gradle/gradle-test-versions.yml");
+                getProjectLayout().getSettingsDirectory().file("gradle/gradle-test-versions.yml");
 
         Provider<GradleTestVersionsConfig> config = getProviderFactory()
                 .fileContents(testVersionsConfigPath)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

gradle/gradle-test-versions.yml was being read from child project directories, rather than the root directory. This meant it couldn't be found. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

We had a [test](https://github.com/palantir/gradle-plugin-testing/blob/develop/gradle-plugin-testing/src/test/groovy/com/palantir/gradle/plugintesting/PluginTestingPluginIntegrationSpec.groovy#L165) for this. IntegrationSpec uses single-project builds, which means the settings and project dirs are the same. Hence the test passed.

However, in a multi-project build, we have to read from the settings directory instead.  

==COMMIT_MSG==
Read gradle/gradle-test-versions.yml from the settings dir, rather than project dir
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

