### PR TITLE
add `@WithGradleVersionsLessThan`, `@WithGradleVersionsGreaterThan`, `@WithGradleVersionsLessThanOrEqualTo` and `@WithGradleVersionsGreaterThanOrEqualTo`

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -11,6 +11,9 @@ This guide covers how to write tests for Gradle plugins using the `gradle-plugin
     - [The @GradlePluginTests Annotation](#the-gradleplugintests-annotation)
     - [Parameter Injection](#parameter-injection)
     - [Multi-Version Testing](#multi-version-testing)
+    - [Adding Versions for Specific Tests](#adding-versions-for-specific-tests)
+    - [Filtering to Specific Versions](#filtering-to-specific-versions)
+    - [Version Comparison Constraints](#version-comparison-constraints)
 - [File Operations](#file-operations)
     - [Working with Files](#working-with-files)
     - [Build Gradle](#build-gradle)
@@ -208,6 +211,65 @@ void test_only_on_8_5(GradleInvoker gradle, RootProject project) {
 ```
 
 The annotation can be applied at the class level to filter all tests in the class, or at the method level for individual tests. Method-level filters are applied in addition to class-level filters.
+
+#### Version Comparison Constraints
+
+For more flexible version filtering, use the comparison annotations to specify version ranges:
+
+- **`@WithGradleVersionsLessThan`** - Run only on versions strictly less than the specified version
+- **`@WithGradleVersionsGreaterThan`** - Run only on versions strictly greater than the specified version
+- **`@WithGradleVersionsLessThanOrEqualTo`** - Run only on versions less than or equal to the specified version
+- **`@WithGradleVersionsGreaterThanOrEqualTo`** - Run only on versions greater than or equal to the specified version
+
+```java
+@GradlePluginTests
+class VersionConstraintTest {
+    @Test
+    @WithGradleVersionsLessThan("8.0")
+    void test_pre_gradle_8_behavior(GradleInvoker gradle, RootProject project) {
+        // Only runs on Gradle versions before 8.0 (e.g., 7.6.5)
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThanOrEqualTo("8.5")
+    void test_new_api_introduced_in_8_5(GradleInvoker gradle, RootProject project) {
+        // Only runs on Gradle 8.5 and later
+    }
+}
+```
+
+**Combining constraints for version ranges:**
+
+You can combine multiple annotations to define precise version ranges:
+
+```java
+@Test
+@WithGradleVersionsGreaterThanOrEqualTo("8.0")
+@WithGradleVersionsLessThan("9.0")
+void test_gradle_8_only(GradleInvoker gradle, RootProject project) {
+    // Runs on Gradle 8.x versions only (>= 8.0 and < 9.0)
+}
+
+@Test
+@WithGradleVersionsGreaterThan("7.6")
+@WithGradleVersionsLessThanOrEqualTo("8.5")
+void test_range_exclusive_inclusive(GradleInvoker gradle, RootProject project) {
+    // Runs on versions > 7.6 and <= 8.5
+}
+```
+
+**Combining with `@WithOnlyGradleVersions`:**
+
+Comparison annotations can be combined with `@WithOnlyGradleVersions` for complex filtering:
+
+```java
+@Test
+@WithOnlyGradleVersions({"8.0", "8.5", "8.10"})
+@WithGradleVersionsLessThanOrEqualTo("8.5")
+void test_subset_with_upper_bound(GradleInvoker gradle, RootProject project) {
+    // Only runs on 8.0 and 8.5 (8.10 is filtered out by the <= 8.5 constraint)
+}
+```
 
 ## File Operations
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleVersion.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleVersion.java
@@ -16,9 +16,15 @@
 
 package com.palantir.gradle.testing.execution;
 
-public record GradleVersion(String version) {
+public record GradleVersion(String version) implements Comparable<GradleVersion> {
     @Override
     public String toString() {
         return version;
+    }
+
+    @Override
+    public int compareTo(GradleVersion other) {
+        return org.gradle.util.GradleVersion.version(this.version)
+                .compareTo(org.gradle.util.GradleVersion.version(other.version));
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/GradleVersions.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/GradleVersions.java
@@ -18,11 +18,14 @@ package com.palantir.gradle.testing.junit;
 
 import com.google.common.base.Splitter;
 import com.palantir.gradle.testing.execution.GradleVersion;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -93,10 +96,46 @@ final class GradleVersions {
     }
 
     private static void applyFilter(Set<GradleVersion> versions, AnnotatedElement element) {
+        applyExactFilter(versions, element);
+        applyComparisonFilter(
+                versions, element, WithGradleVersionsLessThan.class, WithGradleVersionsLessThan::value, v -> v < 0);
+        applyComparisonFilter(
+                versions,
+                element,
+                WithGradleVersionsGreaterThan.class,
+                WithGradleVersionsGreaterThan::value,
+                v -> v > 0);
+        applyComparisonFilter(
+                versions,
+                element,
+                WithGradleVersionsLessThanOrEqualTo.class,
+                WithGradleVersionsLessThanOrEqualTo::value,
+                v -> v <= 0);
+        applyComparisonFilter(
+                versions,
+                element,
+                WithGradleVersionsGreaterThanOrEqualTo.class,
+                WithGradleVersionsGreaterThanOrEqualTo::value,
+                v -> v >= 0);
+    }
+
+    private static void applyExactFilter(Set<GradleVersion> versions, AnnotatedElement element) {
         AnnotationSupport.findAnnotation(element, WithOnlyGradleVersions.class).ifPresent(annotation -> {
             Set<GradleVersion> allowed =
                     Arrays.stream(annotation.value()).map(GradleVersion::new).collect(Collectors.toSet());
             versions.retainAll(allowed);
+        });
+    }
+
+    private static <A extends Annotation> void applyComparisonFilter(
+            Set<GradleVersion> versions,
+            AnnotatedElement element,
+            Class<A> annotationClass,
+            Function<A, String> valueExtractor,
+            Predicate<Integer> comparisonPredicate) {
+        AnnotationSupport.findAnnotation(element, annotationClass).ifPresent(annotation -> {
+            GradleVersion boundVersion = new GradleVersion(valueExtractor.apply(annotation));
+            versions.removeIf(version -> !comparisonPredicate.test(version.compareTo(boundVersion)));
         });
     }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/WithGradleVersionsGreaterThan.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/WithGradleVersionsGreaterThan.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for filtering Gradle versions to only run versions greater than the specified version.
+ *
+ * <p>This annotation filters the available versions to only include those strictly greater than
+ * the specified version (exclusive). For example, {@code @WithGradleVersionsGreaterThan("7.6")}
+ * will run on 8.0 but not on 7.6 or 7.5.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithGradleVersionsGreaterThan {
+
+    /**
+     * The lower bound Gradle version (exclusive).
+     * @return a Gradle version string (e.g., "7.6")
+     */
+    String value();
+
+    /**
+     * Optional reason explaining why this version constraint is applied.
+     * @return the reason for this version constraint
+     */
+    String reason() default "";
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/WithGradleVersionsGreaterThanOrEqualTo.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/WithGradleVersionsGreaterThanOrEqualTo.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for filtering Gradle versions to only run versions greater than or equal to the specified version.
+ *
+ * <p>This annotation filters the available versions to only include those greater than or equal to
+ * the specified version (inclusive). For example, {@code @WithGradleVersionsGreaterThanOrEqualTo("8.0")}
+ * will run on 8.0 and 8.1 but not on 7.6.5.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithGradleVersionsGreaterThanOrEqualTo {
+
+    /**
+     * The lower bound Gradle version (inclusive).
+     * @return a Gradle version string (e.g., "8.0")
+     */
+    String value();
+
+    /**
+     * Optional reason explaining why this version constraint is applied.
+     * @return the reason for this version constraint
+     */
+    String reason() default "";
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/WithGradleVersionsLessThan.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/WithGradleVersionsLessThan.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for filtering Gradle versions to only run versions less than the specified version.
+ *
+ * <p>This annotation filters the available versions to only include those strictly less than
+ * the specified version (exclusive). For example, {@code @WithGradleVersionsLessThan("8.0")}
+ * will run on 7.6.5 but not on 8.0 or 8.1.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithGradleVersionsLessThan {
+
+    /**
+     * The upper bound Gradle version (exclusive).
+     * @return a Gradle version string (e.g., "8.0")
+     */
+    String value();
+
+    /**
+     * Optional reason explaining why this version constraint is applied.
+     * @return the reason for this version constraint
+     */
+    String reason() default "";
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/WithGradleVersionsLessThanOrEqualTo.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/WithGradleVersionsLessThanOrEqualTo.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for filtering Gradle versions to only run versions less than or equal to the specified version.
+ *
+ * <p>This annotation filters the available versions to only include those less than or equal to
+ * the specified version (inclusive). For example, {@code @WithGradleVersionsLessThanOrEqualTo("8.0")}
+ * will run on 7.6.5 and 8.0 but not on 8.1.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithGradleVersionsLessThanOrEqualTo {
+
+    /**
+     * The upper bound Gradle version (inclusive).
+     * @return a Gradle version string (e.g., "8.0")
+     */
+    String value();
+
+    /**
+     * Optional reason explaining why this version constraint is applied.
+     * @return the reason for this version constraint
+     */
+    String reason() default "";
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/CombinedVersionConstraintsTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/CombinedVersionConstraintsTest.java
@@ -1,0 +1,89 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.ete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.example.CombinedVersionConstraintsFixtureTest;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+final class CombinedVersionConstraintsTest {
+
+    @Test
+    void combined_constraints_filter_correctly() {
+        EngineExecutionResults executionResults = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(CombinedVersionConstraintsFixtureTest.class))
+                .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.0,8.5")
+                .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .execute();
+
+        List<Event> finished = executionResults.testEvents().finished().stream().toList();
+        List<Event> skipped = executionResults.testEvents().skipped().stream().toList();
+
+        assertThat(finished)
+                .satisfiesExactlyInAnyOrder(
+                        // test_range_8_0_to_8_5_exclusive: >= 8.0 AND < 8.5 -> only 8.0
+                        ranWithNameAndVersion("test range 8 0 to 8 5 exclusive", "8.0"),
+                        // test_range_after_7_6_5_to_8_5_inclusive: > 7.6.5 AND <= 8.5 -> 8.0 and 8.5
+                        ranWithNameAndVersion("test range after 7 6 5 to 8 5 inclusive", "8.0"),
+                        ranWithNameAndVersion("test range after 7 6 5 to 8 5 inclusive", "8.5"),
+                        // test_only_with_less_than_or_equal: only {8.0, 8.5} AND <= 8.0 -> only 8.0
+                        ranWithNameAndVersion("test only with less than or equal", "8.0"));
+
+        assertThat(skipped)
+                .satisfiesExactlyInAnyOrder(
+                        // test_range_8_0_to_8_5_exclusive skipped for 7.6.5 and 8.5
+                        skippedWithNameAndVersion("test range 8 0 to 8 5 exclusive", "7.6.5"),
+                        skippedWithNameAndVersion("test range 8 0 to 8 5 exclusive", "8.5"),
+                        // test_range_after_7_6_5_to_8_5_inclusive skipped for 7.6.5
+                        skippedWithNameAndVersion("test range after 7 6 5 to 8 5 inclusive", "7.6.5"),
+                        // test_range_exclusive_both_sides_no_match: > 8.0 AND < 8.5 -> none (no versions in between)
+                        skippedWithNameAndVersion("test range exclusive both sides no match", "7.6.5"),
+                        skippedWithNameAndVersion("test range exclusive both sides no match", "8.0"),
+                        skippedWithNameAndVersion("test range exclusive both sides no match", "8.5"),
+                        // test_only_with_less_than_or_equal skipped for 7.6.5 and 8.5
+                        skippedWithNameAndVersion("test only with less than or equal", "7.6.5"),
+                        skippedWithNameAndVersion("test only with less than or equal", "8.5"),
+                        // test_impossible_range: > 9.0 AND < 7.0 -> impossible, all skipped
+                        skippedWithNameAndVersion("test impossible range", "7.6.5"),
+                        skippedWithNameAndVersion("test impossible range", "8.0"),
+                        skippedWithNameAndVersion("test impossible range", "8.5"));
+    }
+
+    private static Consumer<Event> ranWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            Assertions.assertThatRanWithCorrectGradleVersion(
+                    CombinedVersionConstraintsFixtureTest.class, event, gradleVersion, displayNameContains);
+        };
+    }
+
+    private static Consumer<Event> skippedWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            assertThat(event.getTestDescriptor().getParent().map(TestDescriptor::getDisplayName))
+                    .hasValue("Gradle " + gradleVersion);
+        };
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/WithGradleVersionsGreaterThanOrEqualToTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/WithGradleVersionsGreaterThanOrEqualToTest.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.ete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.example.WithGradleVersionsGreaterThanOrEqualToFixtureTest;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+final class WithGradleVersionsGreaterThanOrEqualToTest {
+
+    @Test
+    void greater_than_or_equal_filters_to_versions_at_or_above_bound() {
+        EngineExecutionResults executionResults = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(WithGradleVersionsGreaterThanOrEqualToFixtureTest.class))
+                .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.0,8.5")
+                .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .execute();
+
+        List<Event> finished = executionResults.testEvents().finished().stream().toList();
+        List<Event> skipped = executionResults.testEvents().skipped().stream().toList();
+
+        assertThat(finished)
+                .satisfiesExactlyInAnyOrder(
+                        // test_without_constraint runs on all versions
+                        ranWithNameAndVersion("test without constraint", "7.6.5"),
+                        ranWithNameAndVersion("test without constraint", "8.0"),
+                        ranWithNameAndVersion("test without constraint", "8.5"),
+                        // test_greater_than_or_equal_to_8_0 runs on 8.0 and 8.5
+                        ranWithNameAndVersion("test greater than or equal to 8 0", "8.0"),
+                        ranWithNameAndVersion("test greater than or equal to 8 0", "8.5"),
+                        // test_greater_than_or_equal_to_8_5 only runs on 8.5
+                        ranWithNameAndVersion("test greater than or equal to 8 5", "8.5"));
+
+        assertThat(skipped)
+                .satisfiesExactlyInAnyOrder(
+                        // test_greater_than_or_equal_to_8_0 skipped for 7.6.5
+                        skippedWithNameAndVersion("test greater than or equal to 8 0", "7.6.5"),
+                        // test_greater_than_or_equal_to_8_5 skipped for 7.6.5 and 8.0
+                        skippedWithNameAndVersion("test greater than or equal to 8 5", "7.6.5"),
+                        skippedWithNameAndVersion("test greater than or equal to 8 5", "8.0"),
+                        // test_greater_than_or_equal_to_9_0_no_match skipped for all versions
+                        skippedWithNameAndVersion("test greater than or equal to 9 0 no match", "7.6.5"),
+                        skippedWithNameAndVersion("test greater than or equal to 9 0 no match", "8.0"),
+                        skippedWithNameAndVersion("test greater than or equal to 9 0 no match", "8.5"));
+    }
+
+    private static Consumer<Event> ranWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            Assertions.assertThatRanWithCorrectGradleVersion(
+                    WithGradleVersionsGreaterThanOrEqualToFixtureTest.class, event, gradleVersion, displayNameContains);
+        };
+    }
+
+    private static Consumer<Event> skippedWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            assertThat(event.getTestDescriptor().getParent().map(TestDescriptor::getDisplayName))
+                    .hasValue("Gradle " + gradleVersion);
+        };
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/WithGradleVersionsGreaterThanTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/WithGradleVersionsGreaterThanTest.java
@@ -1,0 +1,84 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.ete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.example.WithGradleVersionsGreaterThanFixtureTest;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+final class WithGradleVersionsGreaterThanTest {
+
+    @Test
+    void greater_than_filters_to_versions_above_bound() {
+        EngineExecutionResults executionResults = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(WithGradleVersionsGreaterThanFixtureTest.class))
+                .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.0,8.5")
+                .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .execute();
+
+        List<Event> finished = executionResults.testEvents().finished().stream().toList();
+        List<Event> skipped = executionResults.testEvents().skipped().stream().toList();
+
+        assertThat(finished)
+                .satisfiesExactlyInAnyOrder(
+                        // test_without_constraint runs on all versions
+                        ranWithNameAndVersion("test without constraint", "7.6.5"),
+                        ranWithNameAndVersion("test without constraint", "8.0"),
+                        ranWithNameAndVersion("test without constraint", "8.5"),
+                        // test_greater_than_8_0 only runs on 8.5
+                        ranWithNameAndVersion("test greater than 8 0", "8.5"),
+                        // test_greater_than_7_6_5 runs on 8.0 and 8.5
+                        ranWithNameAndVersion("test greater than 7 6 5", "8.0"),
+                        ranWithNameAndVersion("test greater than 7 6 5", "8.5"));
+
+        assertThat(skipped)
+                .satisfiesExactlyInAnyOrder(
+                        // test_greater_than_8_0 skipped for 7.6.5 and 8.0
+                        skippedWithNameAndVersion("test greater than 8 0", "7.6.5"),
+                        skippedWithNameAndVersion("test greater than 8 0", "8.0"),
+                        // test_greater_than_7_6_5 skipped for 7.6.5
+                        skippedWithNameAndVersion("test greater than 7 6 5", "7.6.5"),
+                        // test_greater_than_9_0_no_match skipped for all versions
+                        skippedWithNameAndVersion("test greater than 9 0 no match", "7.6.5"),
+                        skippedWithNameAndVersion("test greater than 9 0 no match", "8.0"),
+                        skippedWithNameAndVersion("test greater than 9 0 no match", "8.5"));
+    }
+
+    private static Consumer<Event> ranWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            Assertions.assertThatRanWithCorrectGradleVersion(
+                    WithGradleVersionsGreaterThanFixtureTest.class, event, gradleVersion, displayNameContains);
+        };
+    }
+
+    private static Consumer<Event> skippedWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            assertThat(event.getTestDescriptor().getParent().map(TestDescriptor::getDisplayName))
+                    .hasValue("Gradle " + gradleVersion);
+        };
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/WithGradleVersionsLessThanOrEqualToTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/WithGradleVersionsLessThanOrEqualToTest.java
@@ -1,0 +1,83 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.ete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.example.WithGradleVersionsLessThanOrEqualToFixtureTest;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+final class WithGradleVersionsLessThanOrEqualToTest {
+
+    @Test
+    void less_than_or_equal_filters_to_versions_at_or_below_bound() {
+        EngineExecutionResults executionResults = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(WithGradleVersionsLessThanOrEqualToFixtureTest.class))
+                .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.0,8.5")
+                .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .execute();
+
+        List<Event> finished = executionResults.testEvents().finished().stream().toList();
+        List<Event> skipped = executionResults.testEvents().skipped().stream().toList();
+
+        assertThat(finished)
+                .satisfiesExactlyInAnyOrder(
+                        // test_without_constraint runs on all versions
+                        ranWithNameAndVersion("test without constraint", "7.6.5"),
+                        ranWithNameAndVersion("test without constraint", "8.0"),
+                        ranWithNameAndVersion("test without constraint", "8.5"),
+                        // test_less_than_or_equal_to_8_0 runs on 7.6.5 and 8.0
+                        ranWithNameAndVersion("test less than or equal to 8 0", "7.6.5"),
+                        ranWithNameAndVersion("test less than or equal to 8 0", "8.0"),
+                        // test_less_than_or_equal_to_7_6_5 only runs on 7.6.5
+                        ranWithNameAndVersion("test less than or equal to 7 6 5", "7.6.5"));
+
+        assertThat(skipped)
+                .satisfiesExactlyInAnyOrder(
+                        // test_less_than_or_equal_to_8_0 skipped for 8.5
+                        skippedWithNameAndVersion("test less than or equal to 8 0", "8.5"),
+                        // test_less_than_or_equal_to_7_6_5 skipped for 8.0 and 8.5
+                        skippedWithNameAndVersion("test less than or equal to 7 6 5", "8.0"),
+                        skippedWithNameAndVersion("test less than or equal to 7 6 5", "8.5"),
+                        // test_less_than_or_equal_to_7_0_no_match skipped for all versions
+                        skippedWithNameAndVersion("test less than or equal to 7 0 no match", "7.6.5"),
+                        skippedWithNameAndVersion("test less than or equal to 7 0 no match", "8.0"),
+                        skippedWithNameAndVersion("test less than or equal to 7 0 no match", "8.5"));
+    }
+
+    private static Consumer<Event> ranWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            Assertions.assertThatRanWithCorrectGradleVersion(WithGradleVersionsLessThanOrEqualToFixtureTest.class, event, gradleVersion, displayNameContains);
+        };
+    }
+
+    private static Consumer<Event> skippedWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            assertThat(event.getTestDescriptor().getParent().map(TestDescriptor::getDisplayName))
+                    .hasValue("Gradle " + gradleVersion);
+        };
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/WithGradleVersionsLessThanTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/WithGradleVersionsLessThanTest.java
@@ -1,0 +1,83 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.ete;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.example.WithGradleVersionsLessThanFixtureTest;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.Event;
+
+final class WithGradleVersionsLessThanTest {
+
+    @Test
+    void less_than_filters_to_versions_below_bound() {
+        EngineExecutionResults executionResults = EngineTestKit.engine("junit-jupiter")
+                .selectors(DiscoverySelectors.selectClass(WithGradleVersionsLessThanFixtureTest.class))
+                .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.0,8.5")
+                .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .execute();
+
+        List<Event> finished = executionResults.testEvents().finished().stream().toList();
+        List<Event> skipped = executionResults.testEvents().skipped().stream().toList();
+
+        assertThat(finished)
+                .satisfiesExactlyInAnyOrder(
+                        // test_without_constraint runs on all versions
+                        ranWithNameAndVersion("test without constraint", "7.6.5"),
+                        ranWithNameAndVersion("test without constraint", "8.0"),
+                        ranWithNameAndVersion("test without constraint", "8.5"),
+                        // test_less_than_8_0 only runs on 7.6.5
+                        ranWithNameAndVersion("test less than 8 0", "7.6.5"),
+                        // test_less_than_8_5 runs on 7.6.5 and 8.0
+                        ranWithNameAndVersion("test less than 8 5", "7.6.5"),
+                        ranWithNameAndVersion("test less than 8 5", "8.0"));
+
+        assertThat(skipped)
+                .satisfiesExactlyInAnyOrder(
+                        // test_less_than_8_0 skipped for 8.0 and 8.5
+                        skippedWithNameAndVersion("test less than 8 0", "8.0"),
+                        skippedWithNameAndVersion("test less than 8 0", "8.5"),
+                        // test_less_than_8_5 skipped for 8.5
+                        skippedWithNameAndVersion("test less than 8 5", "8.5"),
+                        // test_less_than_7_0_no_match skipped for all versions
+                        skippedWithNameAndVersion("test less than 7 0 no match", "7.6.5"),
+                        skippedWithNameAndVersion("test less than 7 0 no match", "8.0"),
+                        skippedWithNameAndVersion("test less than 7 0 no match", "8.5"));
+    }
+
+    private static Consumer<Event> ranWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            Assertions.assertThatRanWithCorrectGradleVersion(WithGradleVersionsLessThanFixtureTest.class, event, gradleVersion, displayNameContains);
+        };
+    }
+
+    private static Consumer<Event> skippedWithNameAndVersion(String displayNameContains, String gradleVersion) {
+        return event -> {
+            assertThat(event.getTestDescriptor().getDisplayName()).contains(displayNameContains);
+            assertThat(event.getTestDescriptor().getParent().map(TestDescriptor::getDisplayName))
+                    .hasValue("Gradle " + gradleVersion);
+        };
+    }
+}

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/CombinedVersionConstraintsFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/CombinedVersionConstraintsFixtureTest.java
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.junit.WithGradleVersionsGreaterThan;
+import com.palantir.gradle.testing.junit.WithGradleVersionsGreaterThanOrEqualTo;
+import com.palantir.gradle.testing.junit.WithGradleVersionsLessThan;
+import com.palantir.gradle.testing.junit.WithGradleVersionsLessThanOrEqualTo;
+import com.palantir.gradle.testing.junit.WithOnlyGradleVersions;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test fixture for testing combined version constraints.
+ * This fixture is designed to be run with base versions 7.6.5, 8.0, 8.5 via configuration parameter.
+ */
+@GradlePluginTests
+public class CombinedVersionConstraintsFixtureTest {
+
+    @Test
+    @WithGradleVersionsGreaterThanOrEqualTo("8.0")
+    @WithGradleVersionsLessThan("8.5")
+    void test_range_8_0_to_8_5_exclusive(GradleInvoker gradleInvoker, RootProject rootProject) {
+        // Should only run on 8.0 (>= 8.0 and < 8.5)
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThan("7.6.5")
+    @WithGradleVersionsLessThanOrEqualTo("8.5")
+    void test_range_after_7_6_5_to_8_5_inclusive(GradleInvoker gradleInvoker, RootProject rootProject) {
+        // Should run on 8.0 and 8.5 (> 7.6.5 and <= 8.5)
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThan("8.0")
+    @WithGradleVersionsLessThan("8.5")
+    void test_range_exclusive_both_sides_no_match(GradleInvoker gradleInvoker, RootProject rootProject) {
+        // Should not run on any version (> 8.0 and < 8.5, but no versions in matrix between)
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithOnlyGradleVersions({"8.0", "8.5"})
+    @WithGradleVersionsLessThanOrEqualTo("8.0")
+    void test_only_with_less_than_or_equal(GradleInvoker gradleInvoker, RootProject rootProject) {
+        // Should only run on 8.0 (in {8.0, 8.5} and <= 8.0)
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThan("9.0")
+    @WithGradleVersionsLessThan("7.0")
+    void test_impossible_range(GradleInvoker gradleInvoker, RootProject rootProject) {
+        // Should never run - impossible range (> 9.0 AND < 7.0)
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+}

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/WithGradleVersionsGreaterThanFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/WithGradleVersionsGreaterThanFixtureTest.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.junit.WithGradleVersionsGreaterThan;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test fixture for testing {@link WithGradleVersionsGreaterThan} annotation behavior.
+ * This fixture is designed to be run with base versions 7.6.5, 8.0, 8.5 via configuration parameter.
+ */
+@GradlePluginTests
+public class WithGradleVersionsGreaterThanFixtureTest {
+
+    @Test
+    void test_without_constraint(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThan("8.0")
+    void test_greater_than_8_0(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThan("7.6.5")
+    void test_greater_than_7_6_5(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThan("9.0")
+    void test_greater_than_9_0_no_match(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+}

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/WithGradleVersionsGreaterThanOrEqualToFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/WithGradleVersionsGreaterThanOrEqualToFixtureTest.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.junit.WithGradleVersionsGreaterThanOrEqualTo;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test fixture for testing {@link WithGradleVersionsGreaterThanOrEqualTo} annotation behavior.
+ * This fixture is designed to be run with base versions 7.6.5, 8.0, 8.5 via configuration parameter.
+ */
+@GradlePluginTests
+public class WithGradleVersionsGreaterThanOrEqualToFixtureTest {
+
+    @Test
+    void test_without_constraint(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThanOrEqualTo("8.0")
+    void test_greater_than_or_equal_to_8_0(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThanOrEqualTo("8.5")
+    void test_greater_than_or_equal_to_8_5(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsGreaterThanOrEqualTo("9.0")
+    void test_greater_than_or_equal_to_9_0_no_match(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+}

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/WithGradleVersionsLessThanFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/WithGradleVersionsLessThanFixtureTest.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.junit.WithGradleVersionsLessThan;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test fixture for testing {@link WithGradleVersionsLessThan} annotation behavior.
+ * This fixture is designed to be run with base versions 7.6.5, 8.0, 8.5 via configuration parameter.
+ */
+@GradlePluginTests
+public class WithGradleVersionsLessThanFixtureTest {
+
+    @Test
+    void test_without_constraint(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsLessThan("8.0")
+    void test_less_than_8_0(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsLessThan("8.5")
+    void test_less_than_8_5(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsLessThan("7.0")
+    void test_less_than_7_0_no_match(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+}

--- a/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/WithGradleVersionsLessThanOrEqualToFixtureTest.java
+++ b/gradle-plugin-testing-junit/src/testFixtures/java/com/palantir/example/WithGradleVersionsLessThanOrEqualToFixtureTest.java
@@ -1,0 +1,74 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.example;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.junit.WithGradleVersionsLessThanOrEqualTo;
+import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test fixture for testing {@link WithGradleVersionsLessThanOrEqualTo} annotation behavior.
+ * This fixture is designed to be run with base versions 7.6.5, 8.0, 8.5 via configuration parameter.
+ */
+@GradlePluginTests
+public class WithGradleVersionsLessThanOrEqualToFixtureTest {
+
+    @Test
+    void test_without_constraint(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsLessThanOrEqualTo("8.0")
+    void test_less_than_or_equal_to_8_0(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsLessThanOrEqualTo("7.6.5")
+    void test_less_than_or_equal_to_7_6_5(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+
+    @Test
+    @WithGradleVersionsLessThanOrEqualTo("7.0")
+    void test_less_than_or_equal_to_7_0_no_match(GradleInvoker gradleInvoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            import org.gradle.util.GradleVersion
+            println "GradleVersion: ${GradleVersion.current().version}"
+            """);
+
+        throw new RuntimeException(gradleInvoker.withArgs().buildsSuccessfully().output());
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

When writing tests that need to run on specific Gradle version ranges (e.g., only pre-8.0 versions, or 8.5+), users had to either:
1. Use `@WithOnlyGradleVersions` and manually list every version in the range
2. Add conditional logic inside the test itself

This is tedious and error-prone, especially as new Gradle versions are added to the test matrix.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

Adds four new annotations for filtering tests by Gradle version comparisons:

- `@WithGradleVersionsLessThan("8.0")` - run only on versions < 8.0
- `@WithGradleVersionsGreaterThan("7.6")` - run only on versions > 7.6
- `@WithGradleVersionsLessThanOrEqualTo("8.5")` - run only on versions <= 8.5
- `@WithGradleVersionsGreaterThanOrEqualTo("8.0")` - run only on versions >= 8.0

These can be combined for version ranges:

```java
@Test
@WithGradleVersionsGreaterThanOrEqualTo("8.0")
@WithGradleVersionsLessThan("9.0")
void test_gradle_8_only(GradleInvoker gradle, RootProject project) {
    // Runs on Gradle 8.x versions only
}
```
Version comparison uses Gradle's built-in GradleVersion class for proper semantic version ordering.

==COMMIT_MSG==
Add version comparison annotations for Gradle version filtering

Adds `@WithGradleVersionsLessThan`, `@WithGradleVersionsGreaterThan`,
`@WithGradleVersionsLessThanOrEqualTo`, and `@WithGradleVersionsGreaterThanOrEqualTo`
annotations that filter tests to run only on Gradle versions matching the comparison.

Annotations can be combined for version ranges (e.g., >= 8.0 AND < 9.0).
==COMMIT_MSG==

Possible downsides?

None - this is purely additive functionality.