### PR TITLE
Improve testing guide with migration best practices

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -707,6 +707,27 @@ void file_assertions(GradleInvoker gradle, RootProject project) {
 }
 ```
 
+### Assertion Best Practices
+
+**String Comparisons with Whitespace**: Avoid `isEqualToIgnoringWhitespace()` for trimming - it normalizes ALL whitespace (treating consecutive spaces as single spaces). To match Groovy's `text.trim() == expected` behavior, use:
+
+```java
+assertThat(file.text().trim()).isEqualTo(expected);
+```
+
+**Assertion Descriptions**: Use `.as()` to provide context for assertions instead of comments:
+
+```java
+// Good - description appears in test failure messages
+externalDepsFile.assertThat().as("we generate the correct config").exists();
+
+// Avoid - comment doesn't appear in failure messages
+// we generate the correct config
+externalDepsFile.assertThat().exists();
+```
+
+When migrating Spock tests, convert `then:` block labels to `.as()` calls, but keep `when:` block labels as comments since they describe actions, not assertions.
+
 ## Error Prone Checks
 
 The `gradle-plugin-testing` plugin ships with custom Error Prone checks that are automatically enabled when the `net.ltgt.errorprone` plugin is applied to your project.


### PR DESCRIPTION
## Summary

Adds new "Assertion Best Practices" section to the testing guide covering two common migration issues:
- Proper string comparison with whitespace (avoiding `isEqualToIgnoringWhitespace()` misuse)
- Using `.as()` for assertion descriptions instead of comments

## Motivation

These additions address common issues found during test migrations from Groovy/Spock to Java/JUnit:
- **String comparisons**: `isEqualToIgnoringWhitespace()` normalizes all whitespace, not just trim. This differs from Groovy's `text.trim() == expected` behavior.
- **Assertion descriptions**: Spock `then:` block labels should become `.as()` calls in AssertJ for better test failure messages.

## Source

Issues discovered in:
- palantir/gradle-idea-configuration#207 - Migration incorrectly used `isEqualToIgnoringWhitespace()` and lost assertion context by converting Spock block labels to comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)