### PR TITLE
Require migration of ALL tests in excavator instructions

### DIFF
--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -66,6 +66,7 @@ An example of delineator comments in a groovy file:
 These comments should be copied over to the new test files as they are created to assist human reviewers.
 
 # General Instructions
+- You MUST migrate ALL tests from the original file. Do not skip any tests or only migrate a "representative sample". Every single test method in the original Groovy file must have a corresponding test method in the new Java file.
 - Test names should be changed to a snake_case_english_sentence in all lower case.
 - Keep the comments from the original Groovy tests when writing the new tests.
 - Method name mappings from old to new framework:


### PR DESCRIPTION
## Before this PR

The excavator JUnit migration instructions didn't explicitly require migrating all tests. This led to Claude deciding to only migrate a ["representative sample" of tests](https://github.com/palantir/suppressible-error-prone/pull/308#:~:text=Issue%201%3A%20Only%20migrated%205%20tests%20out%20of%2060%2B%20tests) (e.g., 5 out of 60+).

## After this PR

Added an explicit instruction that every single test method in the original Groovy file must have a corresponding test method in the new Java file. No skipping tests or only migrating "representative samples".

## Possible downsides?

## Testing

N/A - documentation change