### PR TITLE
Add common migration pitfalls to excavator instructions

### DIFF
--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -109,6 +109,27 @@ record PomProject(
 - Follow the instructions in the test-guide.md under "Assertions" for how to use fluent assertions built into the framework.
 - Use chained assertions when checking multiple things on the same value.
 
+# Common Migration Pitfalls
+
+## Plugin Application
+- Do not use `apply plugin: 'foo'` in `build.gradle` text blocks
+- Use the structured `rootProject.buildGradle().plugins().add("plugin-id")` API instead
+
+## Parameterized Tests
+- The framework injects `GradleInvoker`, `RootProject`, etc. as test method parameters
+- `@ParameterizedTest` works with the framework, but the parameterized test parameters must come first
+- Example: `void my_test(String param, GradleInvoker gradle, RootProject rootProject)` - the `String param` from `@MethodSource` comes before the injected parameters
+
+## Helper Methods
+- Helper methods that need gradle/project access should take `GradleInvoker` and/or `RootProject` as parameters
+- Do not store these as instance fields (injection happens per-test)
+
+## Java Text Blocks vs Groovy Triple-Quoted Strings
+- Java text blocks do not preserve a leading newline like Groovy `'''` strings
+- Groovy: `def s = '''\nfoo'''` starts with a newline
+- Java: `String s = """\nfoo"""` also starts with a newline, but `String s = """\n    foo"""` has different indentation behavior
+- When migrating assertions that compare source content, be aware of these differences
+
 # Final Instructions
 - Make sure the migrated tests compile by running `./gradlew compileTestJava`.
 - As you discover errors in your work, write out what the error was and what you did to find the information to fix it to a file called "test-migration-errors.md".


### PR DESCRIPTION
## Before this PR

The excavator migration instructions did not document several common pitfalls discovered during test migrations.

## After this PR

Added a "Common Migration Pitfalls" section documenting:

- **Plugin application**: Must use `plugins().add()` API instead of `apply plugin:` in text blocks
- **Parameterized tests**: `@ParameterizedTest` with `@MethodSource` conflicts with the framework's parameter injection - convert to individual `@Test` methods
- **Helper methods**: Need explicit `GradleInvoker`/`RootProject` parameters rather than instance fields
- **Java text blocks**: Behave differently than Groovy triple-quoted strings regarding leading newlines

These were discovered while migrating `SuppressibleErrorPronePluginIntegrationTest` (57 tests) in palantir/suppressible-error-prone.

## Possible downsides?

## Test plan

- [x] Documentation change only