### PR TITLE
Add migration gotchas and clarify external plugin usage

### DIFF
--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -74,6 +74,7 @@ These comments should be copied over to the new test files as they are created t
     - `.buildAndFail()` → `.buildsWithFailure()`
     - `with('task').build()` → `gradle.withArgs('task').buildsSuccessfully()`
 - When an external plugin is used ensure the correct `gradlePluginForTesting` configuration is added to the projects `build.gradle` file
+- Do NOT add `com.palantir.gradle.plugintesting:gradle-plugin-testing-junit` to `versions.props`. The gradle-plugin-testing plugin automatically provides the correct version of this dependency.
 - When migrating ONLY use the `standardBuildFile` pattern if it was used in the old groovy test
 - If you need to parse a POM / xml file use `jackson` with `records` e.g.
 ```java

--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -131,6 +131,53 @@ record PomProject(
 - Java: `String s = """\nfoo"""` also starts with a newline, but `String s = """\n    foo"""` has different indentation behavior
 - When migrating assertions that compare source content, be aware of these differences
 
+## Don't Use buildscript Blocks for External Plugins
+Do not use `buildscript { }` blocks with `classpath` dependencies to load external plugins. This bypasses TestKit and makes plugins unavailable to the `.plugins().add()` API:
+
+```java
+// WRONG - Don't do this
+rootProject.buildGradle().append("""
+    buildscript {
+        repositories { mavenCentral() }
+        dependencies {
+            classpath 'com.palantir.baseline:gradle-baseline-java:5.38.0'
+        }
+    }
+    apply plugin: 'com.palantir.baseline'
+    """);
+
+// CORRECT - Add to gradlePluginForTesting in build.gradle, then use:
+rootProject.buildGradle().plugins().add("com.palantir.baseline");
+```
+
+## Don't Access Framework Internals
+The framework isolates each test run into its own directory, namespaced by Gradle version. You should never need to know which Gradle version is running.
+
+```java
+// WRONG - Accessing implementation details
+String version = ((DefaultGradleInvoker) gradle).gradleVersion().version();
+Path outputFile = rootProject.buildDir().path()
+    .resolve(String.format("reports/output-%s.xml", version));
+
+// CORRECT - Use simple paths; the framework handles isolation
+Path outputFile = rootProject.buildDir().path().resolve("reports/output.xml");
+```
+
+If you find yourself casting `GradleInvoker` to `DefaultGradleInvoker`, the approach is probably wrong.
+
+## Use Full Task Paths for Explicit Assertions
+When asserting on specific task outcomes, use the full task path including the project name for subproject tasks:
+
+```java
+// WRONG - Task is in subproject, not root
+assertThat(result).task(":checkstyleMain").succeeded();
+
+// CORRECT - Include subproject in path
+assertThat(result).task(":myProject:checkstyleMain").succeeded();
+```
+
+This only matters for explicit task assertions. Running tasks by name (e.g., `gradle.withArgs("checkstyleMain")`) works without the full path since Gradle resolves the task across all projects.
+
 # Final Instructions
 - Make sure the migrated tests compile by running `./gradlew compileTestJava`.
 - As you discover errors in your work, write out what the error was and what you did to find the information to fix it to a file called "test-migration-errors.md".

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -37,6 +37,7 @@ This guide covers how to write tests for Gradle plugins using the `gradle-plugin
 - [Error Prone Checks](#error-prone-checks)
     - [Why We Ship Error Prone Checks](#why-we-ship-error-prone-checks)
     - [Configuring Error Prone](#configuring-error-prone)
+    - [Common Migration Gotchas](#common-migration-gotchas)
 
 ## Quick Start
 
@@ -256,7 +257,7 @@ Use the structured `plugins()` API to add plugins:
 ```java
 @Test
 void add_plugins(RootProject project) {
-    // Add plugins individually
+    // Chain multiple plugins together for readability
     project.buildGradle()
         .plugins()
         .add("java")
@@ -269,17 +270,29 @@ void add_plugins(RootProject project) {
 }
 ```
 
+When adding multiple plugins, chain the `.add()` calls rather than calling `.plugins()` multiple times:
+
+```java
+// Preferred - chain the calls
+rootProject.buildGradle().plugins().add("com.palantir.failure-reports").add("java");
+
+// Avoid - unnecessary repetition
+rootProject.buildGradle().plugins().add("com.palantir.failure-reports");
+rootProject.buildGradle().plugins().add("java");
+```
+
 #### Testing with External Plugins
 
-To test your plugin alongside external Gradle plugins, use the `gradlePluginForTesting` configuration in your projects `build.gradle`. This makes external plugins available in your test's Gradle runtime:
+The `gradlePluginForTesting` configuration is automatically created by the gradle-plugin-testing plugin. Use it to make external Gradle plugins available in your test's Gradle runtime:
 
 ```gradle
 dependencies {
-    gradlePluginForTesting 'com.palantir.sls-packaging:gradle-sls-packaging:<version>'
+    gradlePluginForTesting 'com.palantir.baseline:gradle-baseline-java'
+    gradlePluginForTesting 'com.palantir.sls-packaging:gradle-sls-packaging'
 }
 ```
 
-The plugin is then available in your tests:
+The plugin is then available in your tests using the standard `.plugins().add()` API:
 
 ```java
 @Test
@@ -289,6 +302,24 @@ void test_with_external_plugin(GradleInvoker gradle, RootProject project) {
     gradle.withArgs("tasks").buildsSuccessfully();
 }
 ```
+
+> **Common Mistake**: Do not use `buildscript { }` blocks with `classpath` dependencies to load external plugins. This bypasses TestKit and makes plugins unavailable to the `.plugins().add()` API:
+>
+> ```java
+> // WRONG - Don't do this
+> rootProject.buildGradle().append("""
+>     buildscript {
+>         repositories { mavenCentral() }
+>         dependencies {
+>             classpath 'com.palantir.baseline:gradle-baseline-java:5.38.0'
+>         }
+>     }
+>     apply plugin: 'com.palantir.baseline'
+>     """);
+>
+> // CORRECT - Add to gradlePluginForTesting in build.gradle, then use:
+> rootProject.buildGradle().plugins().add("com.palantir.baseline");
+> ```
 
 **Note:** If you forget to add a plugin to `gradlePluginForTesting`, your test will fail with an error like:
 ```
@@ -751,3 +782,37 @@ plugins {
 ```
 
 The framework's Error Prone checks will be automatically registered and applied to your test code, catching issues at compile time and offering automated fixes where possible.
+
+### Common Migration Gotchas
+
+When migrating from Nebula/Spock tests to this framework, avoid these common mistakes:
+
+#### Don't Access Framework Internals
+
+The framework isolates each test run into its own directory, namespaced by Gradle version. You should never need to know which Gradle version is running.
+
+```java
+// WRONG - Accessing implementation details
+String version = ((DefaultGradleInvoker) gradle).gradleVersion().version();
+Path outputFile = rootProject.buildDir().path()
+    .resolve(String.format("reports/output-%s.xml", version));
+
+// CORRECT - Use simple paths; the framework handles isolation
+Path outputFile = rootProject.buildDir().path().resolve("reports/output.xml");
+```
+
+If you find yourself casting `GradleInvoker` to `DefaultGradleInvoker`, the approach is probably wrong.
+
+#### Use Full Task Paths for Explicit Assertions
+
+When asserting on specific task outcomes, use the full task path including the project name for subproject tasks:
+
+```java
+// WRONG - Task is in subproject, not root
+assertThat(result).task(":checkstyleMain").succeeded();
+
+// CORRECT - Include subproject in path
+assertThat(result).task(":myProject:checkstyleMain").succeeded();
+```
+
+This only matters for explicit task assertions. Running tasks by name (e.g., `gradle.withArgs("checkstyleMain")`) works without the full path since Gradle resolves the task across all projects.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -37,7 +37,6 @@ This guide covers how to write tests for Gradle plugins using the `gradle-plugin
 - [Error Prone Checks](#error-prone-checks)
     - [Why We Ship Error Prone Checks](#why-we-ship-error-prone-checks)
     - [Configuring Error Prone](#configuring-error-prone)
-    - [Common Migration Gotchas](#common-migration-gotchas)
 
 ## Quick Start
 
@@ -257,7 +256,7 @@ Use the structured `plugins()` API to add plugins:
 ```java
 @Test
 void add_plugins(RootProject project) {
-    // Chain multiple plugins together for readability
+    // Add plugins individually
     project.buildGradle()
         .plugins()
         .add("java")
@@ -274,7 +273,9 @@ When adding multiple plugins, chain the `.add()` calls rather than calling `.plu
 
 ```java
 // Preferred - chain the calls
-rootProject.buildGradle().plugins().add("com.palantir.failure-reports").add("java");
+rootProject.buildGradle().plugins()
+    .add("com.palantir.failure-reports")
+    .add("java");
 
 // Avoid - unnecessary repetition
 rootProject.buildGradle().plugins().add("com.palantir.failure-reports");
@@ -302,24 +303,6 @@ void test_with_external_plugin(GradleInvoker gradle, RootProject project) {
     gradle.withArgs("tasks").buildsSuccessfully();
 }
 ```
-
-> **Common Mistake**: Do not use `buildscript { }` blocks with `classpath` dependencies to load external plugins. This bypasses TestKit and makes plugins unavailable to the `.plugins().add()` API:
->
-> ```java
-> // WRONG - Don't do this
-> rootProject.buildGradle().append("""
->     buildscript {
->         repositories { mavenCentral() }
->         dependencies {
->             classpath 'com.palantir.baseline:gradle-baseline-java:5.38.0'
->         }
->     }
->     apply plugin: 'com.palantir.baseline'
->     """);
->
-> // CORRECT - Add to gradlePluginForTesting in build.gradle, then use:
-> rootProject.buildGradle().plugins().add("com.palantir.baseline");
-> ```
 
 **Note:** If you forget to add a plugin to `gradlePluginForTesting`, your test will fail with an error like:
 ```
@@ -782,37 +765,3 @@ plugins {
 ```
 
 The framework's Error Prone checks will be automatically registered and applied to your test code, catching issues at compile time and offering automated fixes where possible.
-
-### Common Migration Gotchas
-
-When migrating from Nebula/Spock tests to this framework, avoid these common mistakes:
-
-#### Don't Access Framework Internals
-
-The framework isolates each test run into its own directory, namespaced by Gradle version. You should never need to know which Gradle version is running.
-
-```java
-// WRONG - Accessing implementation details
-String version = ((DefaultGradleInvoker) gradle).gradleVersion().version();
-Path outputFile = rootProject.buildDir().path()
-    .resolve(String.format("reports/output-%s.xml", version));
-
-// CORRECT - Use simple paths; the framework handles isolation
-Path outputFile = rootProject.buildDir().path().resolve("reports/output.xml");
-```
-
-If you find yourself casting `GradleInvoker` to `DefaultGradleInvoker`, the approach is probably wrong.
-
-#### Use Full Task Paths for Explicit Assertions
-
-When asserting on specific task outcomes, use the full task path including the project name for subproject tasks:
-
-```java
-// WRONG - Task is in subproject, not root
-assertThat(result).task(":checkstyleMain").succeeded();
-
-// CORRECT - Include subproject in path
-assertThat(result).task(":myProject:checkstyleMain").succeeded();
-```
-
-This only matters for explicit task assertions. Running tasks by name (e.g., `gradle.withArgs("checkstyleMain")`) works without the full path since Gradle resolves the task across all projects.


### PR DESCRIPTION
## Before this PR
The testing guide's "Testing with External Plugins" section doesn't clarify that `gradlePluginForTesting` is already created by the plugin, and the example uses an explicit version number.

Migration-specific gotchas were scattered or missing from documentation.

## After this PR

**testing-guide.md (general usage):**
- Clarify that `gradlePluginForTesting` configuration is automatically created by the plugin
- Update example to show multiple dependencies without explicit versions
- Add guidance on chaining `.add()` calls for plugins

**junit-migration-excavator-instructions.md (migration-specific):**
- Add guidance: do not add `gradle-plugin-testing-junit` to `versions.props` as the plugin provides it automatically
- Add "Don't Use buildscript Blocks for External Plugins" section
- Add "Don't Access Framework Internals" section (no need for version-based namespacing)
- Add "Use Full Task Paths for Explicit Assertions" section

Based on issues discovered during review of migration PR https://github.com/palantir/gradle-failure-reports/pull/432

## Possible downsides?
None - documentation only.