### PR TITLE
Add `skipped()`, `fromCache()`, and `noSource()` task outcome assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# gradle-plugin-testing
+
+## API Changes
+
+When updating the gradle-plugin-testing API (adding new methods, changing behavior, etc.), update `docs/testing-guide.md` to document the changes.

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -649,10 +649,19 @@ void task_assertions(GradleInvoker gradle, RootProject project) {
     InvocationResult failure = gradle.withArgs("failingTask").buildsWithFailure();
     assertThat(failure).task(":failingTask").failed();
 
+    // Check task was skipped
+    assertThat(result).task(":skippedTask").skipped();
+
+    // Check task had no source files
+    assertThat(result).task(":compileTestJava").noSource();
+
+    // Check task result was from build cache
+    assertThat(result).task(":compileJava").fromCache();
+
     // Check task was not executed
     assertThat(result).task(":nonExistentTask").notOnTaskGraph();
 
-    // Check specific outcome
+    // Check specific outcome via outcome()
     assertThat(result).task(":compileJava").outcome().isEqualTo(TaskOutcome.FROM_CACHE);
 }
 ```

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertion/TaskOutcomeAssert.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertion/TaskOutcomeAssert.java
@@ -55,6 +55,36 @@ public final class TaskOutcomeAssert extends AbstractObjectAssert<TaskOutcomeAss
         return this;
     }
 
+    /**
+     * Asserts that the task outcome is {@link TaskOutcome#SKIPPED}.
+     *
+     * @return this assertion object for method chaining
+     */
+    public TaskOutcomeAssert skipped() {
+        assertTaskOutcome(TaskOutcome.SKIPPED);
+        return this;
+    }
+
+    /**
+     * Asserts that the task outcome is {@link TaskOutcome#FROM_CACHE}.
+     *
+     * @return this assertion object for method chaining
+     */
+    public TaskOutcomeAssert fromCache() {
+        assertTaskOutcome(TaskOutcome.FROM_CACHE);
+        return this;
+    }
+
+    /**
+     * Asserts that the task outcome is {@link TaskOutcome#NO_SOURCE}.
+     *
+     * @return this assertion object for method chaining
+     */
+    public TaskOutcomeAssert noSource() {
+        assertTaskOutcome(TaskOutcome.NO_SOURCE);
+        return this;
+    }
+
     private void assertTaskOutcome(TaskOutcome expected) {
         as("Expected task outcome to be %s but was %s", expected, actual).isEqualTo(expected);
     }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertion/TaskResultAssert.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/assertion/TaskResultAssert.java
@@ -79,6 +79,39 @@ public final class TaskResultAssert extends AbstractOptionalAssert<TaskResultAss
     }
 
     /**
+     * Asserts that the task was skipped.
+     * <p>
+     * This is equivalent to {@code outcome().skipped()}.
+     *
+     * @return a {@link TaskOutcomeAssert} for fluent assertion chaining
+     */
+    public TaskOutcomeAssert skipped() {
+        return outcome().skipped();
+    }
+
+    /**
+     * Asserts that the task result was retrieved from the build cache.
+     * <p>
+     * This is equivalent to {@code outcome().fromCache()}.
+     *
+     * @return a {@link TaskOutcomeAssert} for fluent assertion chaining
+     */
+    public TaskOutcomeAssert fromCache() {
+        return outcome().fromCache();
+    }
+
+    /**
+     * Asserts that the task had no source files to process.
+     * <p>
+     * This is equivalent to {@code outcome().noSource()}.
+     *
+     * @return a {@link TaskOutcomeAssert} for fluent assertion chaining
+     */
+    public TaskOutcomeAssert noSource() {
+        return outcome().noSource();
+    }
+
+    /**
      * Asserts that the task was not on the task graph.
      *
      * @return this assertion object for method chaining

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -24,6 +24,7 @@ import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -396,11 +397,22 @@ class GradleAssertionsUsageTest {
     @Nested
     class FromCache {
 
-        @Test
-        void can_check_task_fromCache(GradleInvoker gradle, RootProject rootProject) {
+        @BeforeEach
+        void beforeEach(RootProject rootProject) {
+            // Configure a project-local build cache to avoid interference from other tests
+            rootProject.settingsGradle().append("""
+                buildCache {
+                    local {
+                        directory = file('.build-cache')
+                    }
+                }
+                """);
             rootProject.buildGradle().plugins().add("java");
             rootProject.sourceSet("main").java().writeClass("public class Foo {}");
+        }
 
+        @Test
+        void can_check_task_fromCache(GradleInvoker gradle) {
             // --build-cache enables the local on-disk build cache
             gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
 
@@ -415,10 +427,7 @@ class GradleAssertionsUsageTest {
         }
 
         @Test
-        void can_check_task_fromCache_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-            rootProject.buildGradle().plugins().add("java");
-            rootProject.sourceSet("main").java().writeClass("public class Bar {}");
-
+        void can_check_task_fromCache_via_outcome(GradleInvoker gradle) {
             gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
             gradle.withArgs("clean").buildsSuccessfully();
 

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -399,7 +399,7 @@ class GradleAssertionsUsageTest {
             rootProject.buildGradle().plugins().add("java");
             rootProject.sourceSet("main").java().writeClass("public class Foo {}");
 
-            // Enable build cache and run compileJava
+            // --build-cache enables the local on-disk build cache
             gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
 
             // Clean the outputs but keep the cache

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class GradleAssertionsUsageTest {
 
     @Nested
-    class TaskOutcome {
+    class Outcome {
 
         @Test
         void can_check_task_outcome(GradleInvoker gradle, RootProject rootProject) {
@@ -47,7 +47,7 @@ class GradleAssertionsUsageTest {
                     .task(":foo")
                     .as("Task should have SUCCESS outcome")
                     .outcome()
-                    .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.SUCCESS);
+                    .isEqualTo(TaskOutcome.SUCCESS);
         }
 
         @Test
@@ -71,7 +71,7 @@ class GradleAssertionsUsageTest {
                     .task(":foo")
                     .as("Second run should be up to date")
                     .outcome()
-                    .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.UP_TO_DATE);
+                    .isEqualTo(TaskOutcome.UP_TO_DATE);
         }
 
         @Test
@@ -89,7 +89,7 @@ class GradleAssertionsUsageTest {
                             .task(":foo")
                             .as("Task outcome should match")
                             .outcome()
-                            .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.UP_TO_DATE))
+                            .isEqualTo(TaskOutcome.UP_TO_DATE))
                     .withMessageContaining("UP_TO_DATE")
                     .withMessageContaining("SUCCESS");
         }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -395,6 +395,36 @@ class GradleAssertionsUsageTest {
     class FromCache {
 
         @Test
+        void can_check_task_fromCache(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().plugins().add("java");
+            rootProject.sourceSet("main").java().writeClass("public class Foo {}");
+
+            // Enable build cache and run compileJava
+            gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
+
+            // Clean the outputs but keep the cache
+            gradle.withArgs("clean").buildsSuccessfully();
+
+            // Run again - should be from cache
+            InvocationResult result = gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
+
+            assertThat(result).task(":compileJava").fromCache();
+        }
+
+        @Test
+        void can_check_task_fromCache_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().plugins().add("java");
+            rootProject.sourceSet("main").java().writeClass("public class Bar {}");
+
+            gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
+            gradle.withArgs("clean").buildsSuccessfully();
+
+            InvocationResult result = gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
+
+            assertThat(result).task(":compileJava").outcome().fromCache();
+        }
+
+        @Test
         void fromCache_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
             rootProject.buildGradle().append("""
                 tasks.register('foo') {

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -103,7 +103,8 @@ class GradleAssertionsUsageTest {
                             .task(":nonexistent")
                             .as("Task should not be present")
                             .outcome())
-                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+                    .withMessageContaining(
+                            "Expected to find a task result for task ':nonexistent' but there was none.");
         }
     }
 
@@ -142,7 +143,8 @@ class GradleAssertionsUsageTest {
 
             assertThatExceptionOfType(AssertionError.class)
                     .isThrownBy(() -> result.assertThat().task(":nonexistent").succeeded())
-                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+                    .withMessageContaining(
+                            "Expected to find a task result for task ':nonexistent' but there was none.");
         }
 
         @Test
@@ -406,7 +408,8 @@ class GradleAssertionsUsageTest {
             gradle.withArgs("clean").buildsSuccessfully();
 
             // Run again - should be from cache
-            InvocationResult result = gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
+            InvocationResult result =
+                    gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
 
             assertThat(result).task(":compileJava").fromCache();
         }
@@ -419,7 +422,8 @@ class GradleAssertionsUsageTest {
             gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
             gradle.withArgs("clean").buildsSuccessfully();
 
-            InvocationResult result = gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
+            InvocationResult result =
+                    gradle.withArgs("--build-cache", "compileJava").buildsSuccessfully();
 
             assertThat(result).task(":compileJava").outcome().fromCache();
         }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -24,299 +24,328 @@ import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @GradlePluginTests
 class GradleAssertionsUsageTest {
 
-    @Test
-    void can_check_task_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class TaskOutcome {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result)
-                .task(":foo")
-                .as("Task should have SUCCESS outcome")
-                .outcome()
-                .isEqualTo(TaskOutcome.SUCCESS);
-    }
-
-    @Test
-    void can_check_task_is_up_to_date(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
-
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun
-                .assertThat()
-                .task(":foo")
-                .as("Second run should be up to date")
-                .outcome()
-                .isEqualTo(TaskOutcome.UP_TO_DATE);
-    }
+            assertThat(result)
+                    .task(":foo")
+                    .as("Task should have SUCCESS outcome")
+                    .outcome()
+                    .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.SUCCESS);
+        }
 
-    @Test
-    void can_check_output(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            println 'hello from build'
-            """);
+        @Test
+        void can_check_task_is_up_to_date(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
 
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        assertThat(result)
-                .output()
-                .as("Build output should contain expected message")
-                .contains("hello from build");
-    }
-
-    @Test
-    void assertion_fails_when_outcome_does_not_match(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat()
-                        .task(":foo")
-                        .as("Task outcome should match")
-                        .outcome()
-                        .isEqualTo(TaskOutcome.UP_TO_DATE))
-                .withMessageContaining("UP_TO_DATE")
-                .withMessageContaining("SUCCESS");
-    }
-
-    @Test
-    void assertion_fails_when_task_is_not_present(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat()
-                        .task(":nonexistent")
-                        .as("Task should not be present")
-                        .outcome())
-                .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
-    }
-
-    @Test
-    void can_check_task_is_notOnTaskGraph(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        result.assertThat()
-                .task(":nonexistent")
-                .as("Non-existent task should be empty")
-                .notOnTaskGraph();
-    }
-
-    @Test
-    void can_check_task_succeeded(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result).task(":foo").succeeded();
-    }
-
-    @Test
-    void can_check_task_succeeded_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result).task(":foo").outcome().succeeded();
-    }
-
-    @Test
-    void can_check_task_failed(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {
-                    try {
-                        throw new IOException("Some exception")
-                    } catch (Exception e) {
-                        throw new RuntimeException('intentional failure', e)
+                    doLast {
+                        outputFile.asFile.text = 'hello'
                     }
                 }
-            }
-            """);
+                """);
 
-        InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
 
-        result.assertThat().task(":foo").failed();
-        assertThat(result).output().contains("Caused by: java.io.IOException: Some exception");
-    }
+            secondRun
+                    .assertThat()
+                    .task(":foo")
+                    .as("Second run should be up to date")
+                    .outcome()
+                    .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.UP_TO_DATE);
+        }
 
-    @Test
-    void can_check_task_failed_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {
-                    throw new RuntimeException('intentional failure')
+        @Test
+        void assertion_fails_when_outcome_does_not_match(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        result.assertThat().task(":foo").outcome().failed();
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat()
+                            .task(":foo")
+                            .as("Task outcome should match")
+                            .outcome()
+                            .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.UP_TO_DATE))
+                    .withMessageContaining("UP_TO_DATE")
+                    .withMessageContaining("SUCCESS");
+        }
+
+        @Test
+        void assertion_fails_when_task_is_not_present(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat()
+                            .task(":nonexistent")
+                            .as("Task should not be present")
+                            .outcome())
+                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+        }
     }
 
-    @Test
-    void can_check_task_upToDate(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
+    @Nested
+    class Succeeded {
 
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_succeeded(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun.assertThat().task(":foo").upToDate();
-    }
+            assertThat(result).task(":foo").succeeded();
+        }
 
-    @Test
-    void can_check_task_upToDate_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
-
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_succeeded_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun.assertThat().task(":foo").outcome().upToDate();
-    }
+            assertThat(result).task(":foo").outcome().succeeded();
+        }
 
-    @Test
-    void succeeded_fails_when_task_not_present(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
+        @Test
+        void succeeded_fails_when_task_not_present(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":nonexistent").succeeded())
-                .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
-    }
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":nonexistent").succeeded())
+                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+        }
 
-    @Test
-    void succeeded_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
+        @Test
+        void succeeded_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
 
-                doLast {
-                    outputFile.asFile.text = 'hello'
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> secondRun.assertThat().task(":foo").succeeded())
-                .withMessageContaining("Expected task outcome to be SUCCESS but was UP_TO_DATE");
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> secondRun.assertThat().task(":foo").succeeded())
+                    .withMessageContaining("Expected task outcome to be SUCCESS but was UP_TO_DATE");
+        }
     }
 
-    @Test
-    void failed_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class Failed {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_task_failed(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {
+                        try {
+                            throw new IOException("Some exception")
+                        } catch (Exception e) {
+                            throw new RuntimeException('intentional failure', e)
+                        }
+                    }
+                }
+                """);
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").failed())
-                .withMessageContaining("Expected task outcome to be FAILED but was SUCCESS");
+            InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+
+            result.assertThat().task(":foo").failed();
+            assertThat(result).output().contains("Caused by: java.io.IOException: Some exception");
+        }
+
+        @Test
+        void can_check_task_failed_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {
+                        throw new RuntimeException('intentional failure')
+                    }
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+
+            result.assertThat().task(":foo").outcome().failed();
+        }
+
+        @Test
+        void failed_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").failed())
+                    .withMessageContaining("Expected task outcome to be FAILED but was SUCCESS");
+        }
     }
 
-    @Test
-    void upToDate_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class UpToDate {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_task_upToDate(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").upToDate())
-                .withMessageContaining("Expected task outcome to be UP_TO_DATE but was SUCCESS");
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
+                }
+                """);
+
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+
+            secondRun.assertThat().task(":foo").upToDate();
+        }
+
+        @Test
+        void can_check_task_upToDate_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
+
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
+                }
+                """);
+
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+
+            secondRun.assertThat().task(":foo").outcome().upToDate();
+        }
+
+        @Test
+        void upToDate_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").upToDate())
+                    .withMessageContaining("Expected task outcome to be UP_TO_DATE but was SUCCESS");
+        }
     }
 
-    @Test
-    void notOnTaskGraph_fails_when_task_exists(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class NotOnTaskGraph {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_task_is_notOnTaskGraph(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").notOnTaskGraph())
-                .withMessageContaining("Task ':foo' was found on task graph");
+            result.assertThat()
+                    .task(":nonexistent")
+                    .as("Non-existent task should be empty")
+                    .notOnTaskGraph();
+        }
+
+        @Test
+        void notOnTaskGraph_fails_when_task_exists(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").notOnTaskGraph())
+                    .withMessageContaining("Task ':foo' was found on task graph");
+        }
     }
 
-    @Test
-    void can_use_satisfies_and_extracting_on_invocation_result(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class Output {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_output(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                println 'hello from build'
+                """);
 
-        result.assertThat()
-                .satisfies(invocationAssert -> {
-                    invocationAssert.assertThat().task(":foo").succeeded();
-                    invocationAssert.assertThat().output().contains("BUILD SUCCESSFUL");
-                })
-                .extracting(InvocationResult::output)
-                .asString()
-                .contains("foo");
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+            assertThat(result)
+                    .output()
+                    .as("Build output should contain expected message")
+                    .contains("hello from build");
+        }
+    }
+
+    @Nested
+    class FluentApi {
+
+        @Test
+        void can_use_satisfies_and_extracting_on_invocation_result(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            result.assertThat()
+                    .satisfies(invocationAssert -> {
+                        invocationAssert.assertThat().task(":foo").succeeded();
+                        invocationAssert.assertThat().output().contains("BUILD SUCCESSFUL");
+                    })
+                    .extracting(InvocationResult::output)
+                    .asString()
+                    .contains("foo");
+        }
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -304,6 +304,109 @@ class GradleAssertionsUsageTest {
     }
 
     @Nested
+    class SkippedAssertions {
+
+        @Test
+        void can_check_task_skipped(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    onlyIf { false }
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThat(result).task(":foo").skipped();
+        }
+
+        @Test
+        void can_check_task_skipped_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    onlyIf { false }
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThat(result).task(":foo").outcome().skipped();
+        }
+
+        @Test
+        void skipped_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").skipped())
+                    .withMessageContaining("Expected task outcome to be SKIPPED but was SUCCESS");
+        }
+    }
+
+    @Nested
+    class NoSourceAssertions {
+
+        @Test
+        void can_check_task_noSource(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().plugins().add("java");
+
+            InvocationResult result = gradle.withArgs("compileJava").buildsSuccessfully();
+
+            assertThat(result).task(":compileJava").noSource();
+        }
+
+        @Test
+        void can_check_task_noSource_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().plugins().add("java");
+
+            InvocationResult result = gradle.withArgs("compileJava").buildsSuccessfully();
+
+            assertThat(result).task(":compileJava").outcome().noSource();
+        }
+
+        @Test
+        void noSource_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").noSource())
+                    .withMessageContaining("Expected task outcome to be NO_SOURCE but was SUCCESS");
+        }
+    }
+
+    @Nested
+    class FromCacheAssertions {
+
+        @Test
+        void fromCache_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").fromCache())
+                    .withMessageContaining("Expected task outcome to be FROM_CACHE but was SUCCESS");
+        }
+    }
+
+    @Nested
     class OutputAssertions {
 
         @Test

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -24,299 +24,324 @@ import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @GradlePluginTests
 class GradleAssertionsUsageTest {
 
-    @Test
-    void can_check_task_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class TaskOutcomeAssertions {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result)
-                .task(":foo")
-                .as("Task should have SUCCESS outcome")
-                .outcome()
-                .isEqualTo(TaskOutcome.SUCCESS);
-    }
-
-    @Test
-    void can_check_task_is_up_to_date(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
-
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun
-                .assertThat()
-                .task(":foo")
-                .as("Second run should be up to date")
-                .outcome()
-                .isEqualTo(TaskOutcome.UP_TO_DATE);
-    }
+            assertThat(result)
+                    .task(":foo")
+                    .as("Task should have SUCCESS outcome")
+                    .outcome()
+                    .isEqualTo(TaskOutcome.SUCCESS);
+        }
 
-    @Test
-    void can_check_output(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            println 'hello from build'
-            """);
+        @Test
+        void can_check_task_is_up_to_date(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
 
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        assertThat(result)
-                .output()
-                .as("Build output should contain expected message")
-                .contains("hello from build");
-    }
-
-    @Test
-    void assertion_fails_when_outcome_does_not_match(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat()
-                        .task(":foo")
-                        .as("Task outcome should match")
-                        .outcome()
-                        .isEqualTo(TaskOutcome.UP_TO_DATE))
-                .withMessageContaining("UP_TO_DATE")
-                .withMessageContaining("SUCCESS");
-    }
-
-    @Test
-    void assertion_fails_when_task_is_not_present(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat()
-                        .task(":nonexistent")
-                        .as("Task should not be present")
-                        .outcome())
-                .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
-    }
-
-    @Test
-    void can_check_task_is_notOnTaskGraph(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        result.assertThat()
-                .task(":nonexistent")
-                .as("Non-existent task should be empty")
-                .notOnTaskGraph();
-    }
-
-    @Test
-    void can_check_task_succeeded(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result).task(":foo").succeeded();
-    }
-
-    @Test
-    void can_check_task_succeeded_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result).task(":foo").outcome().succeeded();
-    }
-
-    @Test
-    void can_check_task_failed(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {
-                    try {
-                        throw new IOException("Some exception")
-                    } catch (Exception e) {
-                        throw new RuntimeException('intentional failure', e)
+                    doLast {
+                        outputFile.asFile.text = 'hello'
                     }
                 }
-            }
-            """);
+                """);
 
-        InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
 
-        result.assertThat().task(":foo").failed();
-        assertThat(result).output().contains("Caused by: java.io.IOException: Some exception");
-    }
+            secondRun
+                    .assertThat()
+                    .task(":foo")
+                    .as("Second run should be up to date")
+                    .outcome()
+                    .isEqualTo(TaskOutcome.UP_TO_DATE);
+        }
 
-    @Test
-    void can_check_task_failed_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {
-                    throw new RuntimeException('intentional failure')
+        @Test
+        void assertion_fails_when_outcome_does_not_match(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        result.assertThat().task(":foo").outcome().failed();
-    }
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat()
+                            .task(":foo")
+                            .as("Task outcome should match")
+                            .outcome()
+                            .isEqualTo(TaskOutcome.UP_TO_DATE))
+                    .withMessageContaining("UP_TO_DATE")
+                    .withMessageContaining("SUCCESS");
+        }
 
-    @Test
-    void can_check_task_upToDate(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
+        @Test
+        void assertion_fails_when_task_is_not_present(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
 
-                doLast {
-                    outputFile.asFile.text = 'hello'
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat()
+                            .task(":nonexistent")
+                            .as("Task should not be present")
+                            .outcome())
+                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+        }
+
+        @Test
+        void can_check_task_is_notOnTaskGraph(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+            result.assertThat()
+                    .task(":nonexistent")
+                    .as("Non-existent task should be empty")
+                    .notOnTaskGraph();
+        }
+
+        @Test
+        void notOnTaskGraph_fails_when_task_exists(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun.assertThat().task(":foo").upToDate();
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").notOnTaskGraph())
+                    .withMessageContaining("Task ':foo' was found on task graph");
+        }
     }
 
-    @Test
-    void can_check_task_upToDate_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
+    @Nested
+    class SucceededAssertions {
 
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_succeeded(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun.assertThat().task(":foo").outcome().upToDate();
-    }
+            assertThat(result).task(":foo").succeeded();
+        }
 
-    @Test
-    void succeeded_fails_when_task_not_present(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":nonexistent").succeeded())
-                .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
-    }
-
-    @Test
-    void succeeded_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
-
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_succeeded_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> secondRun.assertThat().task(":foo").succeeded())
-                .withMessageContaining("Expected task outcome to be SUCCESS but was UP_TO_DATE");
+            assertThat(result).task(":foo").outcome().succeeded();
+        }
+
+        @Test
+        void succeeded_fails_when_task_not_present(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":nonexistent").succeeded())
+                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+        }
+
+        @Test
+        void succeeded_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
+
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
+                }
+                """);
+
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> secondRun.assertThat().task(":foo").succeeded())
+                    .withMessageContaining("Expected task outcome to be SUCCESS but was UP_TO_DATE");
+        }
     }
 
-    @Test
-    void failed_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class FailedAssertions {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_task_failed(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {
+                        try {
+                            throw new IOException("Some exception")
+                        } catch (Exception e) {
+                            throw new RuntimeException('intentional failure', e)
+                        }
+                    }
+                }
+                """);
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").failed())
-                .withMessageContaining("Expected task outcome to be FAILED but was SUCCESS");
+            InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+
+            result.assertThat().task(":foo").failed();
+            assertThat(result).output().contains("Caused by: java.io.IOException: Some exception");
+        }
+
+        @Test
+        void can_check_task_failed_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {
+                        throw new RuntimeException('intentional failure')
+                    }
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+
+            result.assertThat().task(":foo").outcome().failed();
+        }
+
+        @Test
+        void failed_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").failed())
+                    .withMessageContaining("Expected task outcome to be FAILED but was SUCCESS");
+        }
     }
 
-    @Test
-    void upToDate_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class UpToDateAssertions {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_task_upToDate(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").upToDate())
-                .withMessageContaining("Expected task outcome to be UP_TO_DATE but was SUCCESS");
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
+                }
+                """);
+
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+
+            secondRun.assertThat().task(":foo").upToDate();
+        }
+
+        @Test
+        void can_check_task_upToDate_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
+
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
+                }
+                """);
+
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+
+            secondRun.assertThat().task(":foo").outcome().upToDate();
+        }
+
+        @Test
+        void upToDate_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").upToDate())
+                    .withMessageContaining("Expected task outcome to be UP_TO_DATE but was SUCCESS");
+        }
     }
 
-    @Test
-    void notOnTaskGraph_fails_when_task_exists(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class OutputAssertions {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_output(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                println 'hello from build'
+                """);
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").notOnTaskGraph())
-                .withMessageContaining("Task ':foo' was found on task graph");
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+            assertThat(result)
+                    .output()
+                    .as("Build output should contain expected message")
+                    .contains("hello from build");
+        }
     }
 
-    @Test
-    void can_use_satisfies_and_extracting_on_invocation_result(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class FluentApiUsage {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_use_satisfies_and_extracting_on_invocation_result(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
 
-        result.assertThat()
-                .satisfies(invocationAssert -> {
-                    invocationAssert.assertThat().task(":foo").succeeded();
-                    invocationAssert.assertThat().output().contains("BUILD SUCCESSFUL");
-                })
-                .extracting(InvocationResult::output)
-                .asString()
-                .contains("foo");
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            result.assertThat()
+                    .satisfies(invocationAssert -> {
+                        invocationAssert.assertThat().task(":foo").succeeded();
+                        invocationAssert.assertThat().output().contains("BUILD SUCCESSFUL");
+                    })
+                    .extracting(InvocationResult::output)
+                    .asString()
+                    .contains("foo");
+        }
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #355 being merged first.

## Before this PR

The task assertion API had convenience methods for `succeeded()`, `failed()`, and `upToDate()` but was missing them for the other three `TaskOutcome` values: `SKIPPED`, `FROM_CACHE`, and `NO_SOURCE`.

You could use `.outcome().isEqualTo(TaskOutcome.SKIPPED)` but this is less slick than the existing convenience methods:

```java
// Verbose
assertThat(result).task(":compileJava").outcome().isEqualTo(TaskOutcome.SKIPPED);

// vs existing convenience methods for other outcomes
assertThat(result).task(":compileJava").succeeded();
```

See [suppressible-error-prone@4a9a6a6:L869-871](https://github.com/palantir/suppressible-error-prone/blob/4a9a6a6/gradle-suppressible-error-prone/src/test/java/com/palantir/gradle/suppressibleerrorprone/SuppressibleErrorPronePluginIntegrationTest.java#L869-L871) for an example of code that would benefit from this.

## After this PR

Adds the missing convenience methods to both `TaskOutcomeAssert` and `TaskResultAssert`:

- `skipped()` - asserts `TaskOutcome.SKIPPED`
- `fromCache()` - asserts `TaskOutcome.FROM_CACHE`  
- `noSource()` - asserts `TaskOutcome.NO_SOURCE`

Usage:

```java
assertThat(result).task(":compileJava").skipped();
assertThat(result).task(":compileJava").outcome().skipped();
```

## Possible downsides?

## Possible alternatives?