### PR TITLE
Group `GradleAssertionsUsageTest` using `@Nested` classes

### DIFF
--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class GradleAssertionsUsageTest {
 
     @Nested
-    class TaskOutcome {
+    class Outcome {
 
         @Test
         void can_check_task_outcome(GradleInvoker gradle, RootProject rootProject) {
@@ -47,7 +47,7 @@ class GradleAssertionsUsageTest {
                     .task(":foo")
                     .as("Task should have SUCCESS outcome")
                     .outcome()
-                    .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.SUCCESS);
+                    .isEqualTo(TaskOutcome.SUCCESS);
         }
 
         @Test
@@ -71,7 +71,7 @@ class GradleAssertionsUsageTest {
                     .task(":foo")
                     .as("Second run should be up to date")
                     .outcome()
-                    .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.UP_TO_DATE);
+                    .isEqualTo(TaskOutcome.UP_TO_DATE);
         }
 
         @Test
@@ -89,7 +89,7 @@ class GradleAssertionsUsageTest {
                             .task(":foo")
                             .as("Task outcome should match")
                             .outcome()
-                            .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.UP_TO_DATE))
+                            .isEqualTo(TaskOutcome.UP_TO_DATE))
                     .withMessageContaining("UP_TO_DATE")
                     .withMessageContaining("SUCCESS");
         }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -103,7 +103,8 @@ class GradleAssertionsUsageTest {
                             .task(":nonexistent")
                             .as("Task should not be present")
                             .outcome())
-                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+                    .withMessageContaining(
+                            "Expected to find a task result for task ':nonexistent' but there was none.");
         }
     }
 
@@ -142,7 +143,8 @@ class GradleAssertionsUsageTest {
 
             assertThatExceptionOfType(AssertionError.class)
                     .isThrownBy(() -> result.assertThat().task(":nonexistent").succeeded())
-                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+                    .withMessageContaining(
+                            "Expected to find a task result for task ':nonexistent' but there was none.");
         }
 
         @Test

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/GradleAssertionsUsageTest.java
@@ -24,299 +24,328 @@ import com.palantir.gradle.testing.execution.InvocationResult;
 import com.palantir.gradle.testing.execution.TaskOutcome;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.RootProject;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @GradlePluginTests
 class GradleAssertionsUsageTest {
 
-    @Test
-    void can_check_task_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class TaskOutcome {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result)
-                .task(":foo")
-                .as("Task should have SUCCESS outcome")
-                .outcome()
-                .isEqualTo(TaskOutcome.SUCCESS);
-    }
-
-    @Test
-    void can_check_task_is_up_to_date(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
-
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun
-                .assertThat()
-                .task(":foo")
-                .as("Second run should be up to date")
-                .outcome()
-                .isEqualTo(TaskOutcome.UP_TO_DATE);
-    }
+            assertThat(result)
+                    .task(":foo")
+                    .as("Task should have SUCCESS outcome")
+                    .outcome()
+                    .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.SUCCESS);
+        }
 
-    @Test
-    void can_check_output(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            println 'hello from build'
-            """);
+        @Test
+        void can_check_task_is_up_to_date(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
 
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        assertThat(result)
-                .output()
-                .as("Build output should contain expected message")
-                .contains("hello from build");
-    }
-
-    @Test
-    void assertion_fails_when_outcome_does_not_match(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat()
-                        .task(":foo")
-                        .as("Task outcome should match")
-                        .outcome()
-                        .isEqualTo(TaskOutcome.UP_TO_DATE))
-                .withMessageContaining("UP_TO_DATE")
-                .withMessageContaining("SUCCESS");
-    }
-
-    @Test
-    void assertion_fails_when_task_is_not_present(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat()
-                        .task(":nonexistent")
-                        .as("Task should not be present")
-                        .outcome())
-                .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
-    }
-
-    @Test
-    void can_check_task_is_notOnTaskGraph(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
-
-        result.assertThat()
-                .task(":nonexistent")
-                .as("Non-existent task should be empty")
-                .notOnTaskGraph();
-    }
-
-    @Test
-    void can_check_task_succeeded(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result).task(":foo").succeeded();
-    }
-
-    @Test
-    void can_check_task_succeeded_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
-
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
-
-        assertThat(result).task(":foo").outcome().succeeded();
-    }
-
-    @Test
-    void can_check_task_failed(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {
-                    try {
-                        throw new IOException("Some exception")
-                    } catch (Exception e) {
-                        throw new RuntimeException('intentional failure', e)
+                    doLast {
+                        outputFile.asFile.text = 'hello'
                     }
                 }
-            }
-            """);
+                """);
 
-        InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
 
-        result.assertThat().task(":foo").failed();
-        assertThat(result).output().contains("Caused by: java.io.IOException: Some exception");
-    }
+            secondRun
+                    .assertThat()
+                    .task(":foo")
+                    .as("Second run should be up to date")
+                    .outcome()
+                    .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.UP_TO_DATE);
+        }
 
-    @Test
-    void can_check_task_failed_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {
-                    throw new RuntimeException('intentional failure')
+        @Test
+        void assertion_fails_when_outcome_does_not_match(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        result.assertThat().task(":foo").outcome().failed();
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat()
+                            .task(":foo")
+                            .as("Task outcome should match")
+                            .outcome()
+                            .isEqualTo(com.palantir.gradle.testing.execution.TaskOutcome.UP_TO_DATE))
+                    .withMessageContaining("UP_TO_DATE")
+                    .withMessageContaining("SUCCESS");
+        }
+
+        @Test
+        void assertion_fails_when_task_is_not_present(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat()
+                            .task(":nonexistent")
+                            .as("Task should not be present")
+                            .outcome())
+                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+        }
     }
 
-    @Test
-    void can_check_task_upToDate(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
+    @Nested
+    class Succeeded {
 
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_succeeded(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun.assertThat().task(":foo").upToDate();
-    }
+            assertThat(result).task(":foo").succeeded();
+        }
 
-    @Test
-    void can_check_task_upToDate_via_outcome(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
-
-                doLast {
-                    outputFile.asFile.text = 'hello'
+        @Test
+        void can_check_task_succeeded_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
 
-        secondRun.assertThat().task(":foo").outcome().upToDate();
-    }
+            assertThat(result).task(":foo").outcome().succeeded();
+        }
 
-    @Test
-    void succeeded_fails_when_task_not_present(GradleInvoker gradle) {
-        InvocationResult result = gradle.withArgs().buildsSuccessfully();
+        @Test
+        void succeeded_fails_when_task_not_present(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":nonexistent").succeeded())
-                .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
-    }
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":nonexistent").succeeded())
+                    .withMessageContaining("Expected to find a task result for task ':nonexistent' but there was none.");
+        }
 
-    @Test
-    void succeeded_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                def outputFile = layout.projectDirectory.file('foo.txt')
-                outputs.file(outputFile)
+        @Test
+        void succeeded_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
 
-                doLast {
-                    outputFile.asFile.text = 'hello'
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
                 }
-            }
-            """);
+                """);
 
-        gradle.withArgs("foo").buildsSuccessfully();
-        InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> secondRun.assertThat().task(":foo").succeeded())
-                .withMessageContaining("Expected task outcome to be SUCCESS but was UP_TO_DATE");
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> secondRun.assertThat().task(":foo").succeeded())
+                    .withMessageContaining("Expected task outcome to be SUCCESS but was UP_TO_DATE");
+        }
     }
 
-    @Test
-    void failed_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class Failed {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_task_failed(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {
+                        try {
+                            throw new IOException("Some exception")
+                        } catch (Exception e) {
+                            throw new RuntimeException('intentional failure', e)
+                        }
+                    }
+                }
+                """);
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").failed())
-                .withMessageContaining("Expected task outcome to be FAILED but was SUCCESS");
+            InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+
+            result.assertThat().task(":foo").failed();
+            assertThat(result).output().contains("Caused by: java.io.IOException: Some exception");
+        }
+
+        @Test
+        void can_check_task_failed_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {
+                        throw new RuntimeException('intentional failure')
+                    }
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsWithFailure();
+
+            result.assertThat().task(":foo").outcome().failed();
+        }
+
+        @Test
+        void failed_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").failed())
+                    .withMessageContaining("Expected task outcome to be FAILED but was SUCCESS");
+        }
     }
 
-    @Test
-    void upToDate_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class UpToDate {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_task_upToDate(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").upToDate())
-                .withMessageContaining("Expected task outcome to be UP_TO_DATE but was SUCCESS");
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
+                }
+                """);
+
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+
+            secondRun.assertThat().task(":foo").upToDate();
+        }
+
+        @Test
+        void can_check_task_upToDate_via_outcome(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    def outputFile = layout.projectDirectory.file('foo.txt')
+                    outputs.file(outputFile)
+
+                    doLast {
+                        outputFile.asFile.text = 'hello'
+                    }
+                }
+                """);
+
+            gradle.withArgs("foo").buildsSuccessfully();
+            InvocationResult secondRun = gradle.withArgs("foo").buildsSuccessfully();
+
+            secondRun.assertThat().task(":foo").outcome().upToDate();
+        }
+
+        @Test
+        void upToDate_fails_when_outcome_is_different(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").upToDate())
+                    .withMessageContaining("Expected task outcome to be UP_TO_DATE but was SUCCESS");
+        }
     }
 
-    @Test
-    void notOnTaskGraph_fails_when_task_exists(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class NotOnTaskGraph {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_task_is_notOnTaskGraph(GradleInvoker gradle) {
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
 
-        assertThatExceptionOfType(AssertionError.class)
-                .isThrownBy(() -> result.assertThat().task(":foo").notOnTaskGraph())
-                .withMessageContaining("Task ':foo' was found on task graph");
+            result.assertThat()
+                    .task(":nonexistent")
+                    .as("Non-existent task should be empty")
+                    .notOnTaskGraph();
+        }
+
+        @Test
+        void notOnTaskGraph_fails_when_task_exists(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            assertThatExceptionOfType(AssertionError.class)
+                    .isThrownBy(() -> result.assertThat().task(":foo").notOnTaskGraph())
+                    .withMessageContaining("Task ':foo' was found on task graph");
+        }
     }
 
-    @Test
-    void can_use_satisfies_and_extracting_on_invocation_result(GradleInvoker gradle, RootProject rootProject) {
-        rootProject.buildGradle().append("""
-            tasks.register('foo') {
-                doLast {}
-            }
-            """);
+    @Nested
+    class Output {
 
-        InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+        @Test
+        void can_check_output(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                println 'hello from build'
+                """);
 
-        result.assertThat()
-                .satisfies(invocationAssert -> {
-                    invocationAssert.assertThat().task(":foo").succeeded();
-                    invocationAssert.assertThat().output().contains("BUILD SUCCESSFUL");
-                })
-                .extracting(InvocationResult::output)
-                .asString()
-                .contains("foo");
+            InvocationResult result = gradle.withArgs().buildsSuccessfully();
+
+            assertThat(result)
+                    .output()
+                    .as("Build output should contain expected message")
+                    .contains("hello from build");
+        }
+    }
+
+    @Nested
+    class FluentApi {
+
+        @Test
+        void can_use_satisfies_and_extracting_on_invocation_result(GradleInvoker gradle, RootProject rootProject) {
+            rootProject.buildGradle().append("""
+                tasks.register('foo') {
+                    doLast {}
+                }
+                """);
+
+            InvocationResult result = gradle.withArgs("foo").buildsSuccessfully();
+
+            result.assertThat()
+                    .satisfies(invocationAssert -> {
+                        invocationAssert.assertThat().task(":foo").succeeded();
+                        invocationAssert.assertThat().output().contains("BUILD SUCCESSFUL");
+                    })
+                    .extracting(InvocationResult::output)
+                    .asString()
+                    .contains("foo");
+        }
     }
 }


### PR DESCRIPTION
## Before this PR

All assertion tests in `GradleAssertionsUsageTest` were flat at the top level, making it harder to navigate and understand the test structure.

## After this PR

Tests are grouped into `@Nested` classes by assertion type:
- `Outcome` - general task outcome checks
- `Succeeded` - `succeeded()` method tests
- `Failed` - `failed()` method tests
- `UpToDate` - `upToDate()` method tests
- `NotOnTaskGraph` - `notOnTaskGraph()` method tests
- `Output` - output assertion tests
- `FluentApi` - fluent API usage examples

This makes it easier to add new assertion methods in the future by placing their tests in the appropriate nested class.

Note: This is a pure reorganization - tests have been moved into nested classes but not otherwise changed.

## Possible downsides?

## Possible alternatives?