### PR TITLE
Package-private `DefaultGradleInvoker` class

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -23,7 +23,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import org.gradle.testkit.runner.GradleRunner;
 
-public record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) implements GradleInvoker {
+record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) implements GradleInvoker {
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
     public DefaultGradleInvoker {}
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
@@ -16,6 +16,8 @@
 
 package com.palantir.gradle.testing.execution;
 
+import com.google.errorprone.annotations.RestrictedApi;
+import com.palantir.gradle.testing.RestrictedCreation;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import org.slf4j.Logger;
@@ -28,7 +30,7 @@ public interface GradleInvoker {
     GradleInvocation withArgs(String... args);
 
     static GradleInvoker create(Path path, GradleVersion gradleVersion, boolean configurationCache) {
-        DefaultGradleInvoker gradleInvoker = new DefaultGradleInvoker(path, gradleVersion);
+        GradleInvoker gradleInvoker = getInternalDefaultInvoker(path, gradleVersion);
         if (configurationCache) {
             if (shouldRunInTestkitDebugMode()) {
                 log.warn("Configuration cache disabled because debug mode is active. Debug mode and"
@@ -39,6 +41,14 @@ public interface GradleInvoker {
             return new ConfigurationCacheInvoker(path, gradleInvoker);
         }
         return gradleInvoker;
+    }
+
+    @RestrictedApi(
+            explanation =
+                    "For internal use only. Always prefer GradleInvoker#create for the creation of the GradleInvokers.",
+            allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
+    static GradleInvoker getInternalDefaultInvoker(Path path, GradleVersion gradleVersion) {
+        return new DefaultGradleInvoker(path, gradleVersion);
     }
 
     static boolean shouldRunInTestkitDebugMode() {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepo.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepo.java
@@ -18,7 +18,9 @@ package com.palantir.gradle.testing.maven;
 
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
+import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.GradleVersion;
+import com.palantir.gradle.testing.project.RootProject;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -50,14 +52,17 @@ import java.util.List;
  * </pre>
  */
 public final class MavenRepo {
-    private final Path path;
+    private final Path mavenRepoUrl;
     private final MavenRepoPublisher publisher;
 
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
     public MavenRepo(Path repoDir, GradleVersion gradleVersion) {
-        this.path = repoDir.resolve("localMavenRepository").toAbsolutePath();
-        this.publisher =
-                new MavenRepoPublisher(repoDir.resolve("localMavenRepositoryPublisherProject"), path, gradleVersion);
+        this.mavenRepoUrl = repoDir.resolve("localMavenRepository").toAbsolutePath();
+        Path repoDirPath = repoDir.resolve("localMavenRepositoryPublisherProject");
+        this.publisher = new MavenRepoPublisher(
+                mavenRepoUrl,
+                new RootProject(repoDirPath),
+                GradleInvoker.getInternalDefaultInvoker(repoDirPath, gradleVersion));
     }
 
     /**
@@ -79,6 +84,6 @@ public final class MavenRepo {
     }
 
     public Path path() {
-        return path;
+        return mavenRepoUrl;
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepoPublisher.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepoPublisher.java
@@ -17,7 +17,6 @@
 package com.palantir.gradle.testing.maven;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
-import com.palantir.gradle.testing.execution.GradleVersion;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.gradle.testing.project.SubProject;
 import java.nio.file.Path;
@@ -33,10 +32,10 @@ final class MavenRepoPublisher {
     private final GradleInvoker gradleInvoker;
     private final Path mavenRepoUrl;
 
-    MavenRepoPublisher(Path projectRoot, Path mavenRepoUrl, GradleVersion gradleVersion) {
-        this.rootProject = new RootProject(projectRoot);
-        this.gradleInvoker = GradleInvoker.getInternalDefaultInvoker(projectRoot, gradleVersion);
+    MavenRepoPublisher(Path mavenRepoUrl, RootProject rootProject, GradleInvoker gradleInvoker) {
         this.mavenRepoUrl = mavenRepoUrl;
+        this.rootProject = rootProject;
+        this.gradleInvoker = gradleInvoker;
 
         rootProject.settingsGradle().rootProjectName("maven-repo-publisher");
     }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepoPublisher.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepoPublisher.java
@@ -16,7 +16,6 @@
 
 package com.palantir.gradle.testing.maven;
 
-import com.palantir.gradle.testing.execution.DefaultGradleInvoker;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.GradleVersion;
 import com.palantir.gradle.testing.project.RootProject;
@@ -36,7 +35,7 @@ final class MavenRepoPublisher {
 
     MavenRepoPublisher(Path projectRoot, Path mavenRepoUrl, GradleVersion gradleVersion) {
         this.rootProject = new RootProject(projectRoot);
-        this.gradleInvoker = new DefaultGradleInvoker(projectRoot, gradleVersion);
+        this.gradleInvoker = GradleInvoker.getInternalDefaultInvoker(projectRoot, gradleVersion);
         this.mavenRepoUrl = mavenRepoUrl;
 
         rootProject.settingsGradle().rootProjectName("maven-repo-publisher");


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
`MavenRepoPublisher` needs to instantiate a defaultInvoker (it shouldn't require the extra decorations eg. Configuration Cache etc.) (discussion [here](https://github.com/palantir/gradle-plugin-testing/pull/364#discussion_r2758525463))

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Made package-private `DefaultGradleInvoker` class. Introduced restricted internal method for creating a defaultInvoker.
==COMMIT_MSG==
Package-private `DefaultGradleInvoker` class
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

