### PR TITLE
Add `GradleTestTypedFile` Error Prone check

### DIFF
--- a/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestTypedFile.java
+++ b/gradle-plugin-testing-error-prone/src/main/java/com/palantir/gradle/testing/errorprone/GradleTestTypedFile.java
@@ -1,0 +1,100 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.errorprone;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.BugPattern.SeverityLevel;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.matchers.Matcher;
+import com.google.errorprone.matchers.Matchers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LiteralTree;
+import com.sun.source.tree.MethodInvocationTree;
+import java.util.Map;
+
+@AutoService(BugChecker.class)
+@BugPattern(severity = SeverityLevel.ERROR, summary = """
+    Use the typed file method instead of .file() to get IDE syntax highlighting for file contents. \
+    For example, use .yamlFile("config.yml") instead of .file("config.yml").\
+    """)
+public final class GradleTestTypedFile extends BugChecker implements BugChecker.MethodInvocationTreeMatcher {
+    private static final Matcher<ExpressionTree> DIRECTORY_FILE_METHOD = Matchers.instanceMethod()
+            .onDescendantOf("com.palantir.gradle.testing.files.Directory")
+            .named("file");
+
+    private static final Map<String, String> EXTENSION_TO_METHOD = Map.of(
+            ".yml", "yamlFile",
+            ".yaml", "yamlFile",
+            ".gradle", "gradleFile",
+            ".properties", "propertiesFile");
+
+    @Override
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
+        if (!DIRECTORY_FILE_METHOD.matches(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        if (!GradlePluginTestHelpers.isWithinGradlePluginTests(tree, state)) {
+            return Description.NO_MATCH;
+        }
+
+        if (tree.getArguments().size() != 1) {
+            return Description.NO_MATCH;
+        }
+
+        ExpressionTree arg = tree.getArguments().get(0);
+
+        if (!(arg instanceof LiteralTree lit) || !(lit.getValue() instanceof String filename)) {
+            return Description.NO_MATCH;
+        }
+
+        String typedMethod = findTypedMethod(filename);
+        if (typedMethod == null) {
+            return Description.NO_MATCH;
+        }
+
+        return buildDescription(tree)
+                .addFix(createFix(tree, typedMethod, state))
+                .build();
+    }
+
+    private static String findTypedMethod(String filename) {
+        for (Map.Entry<String, String> entry : EXTENSION_TO_METHOD.entrySet()) {
+            if (filename.endsWith(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static SuggestedFix createFix(MethodInvocationTree tree, String typedMethod, VisitorState state) {
+        String methodSelect = state.getSourceForNode(tree.getMethodSelect());
+        int lastDot = methodSelect.lastIndexOf('.');
+        String newMethodSelect;
+        if (lastDot >= 0) {
+            newMethodSelect = methodSelect.substring(0, lastDot + 1) + typedMethod;
+        } else {
+            newMethodSelect = typedMethod;
+        }
+        String argSource = state.getSourceForNode(tree.getArguments().get(0));
+        return SuggestedFix.replace(tree, newMethodSelect + "(" + argSource + ")");
+    }
+}

--- a/gradle-plugin-testing-error-prone/src/test/java/com/palantir/gradle/testing/errorprone/GradleTestTypedFileTest.java
+++ b/gradle-plugin-testing-error-prone/src/test/java/com/palantir/gradle/testing/errorprone/GradleTestTypedFileTest.java
@@ -1,0 +1,268 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.errorprone;
+
+import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.CompilationTestHelper;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+class GradleTestTypedFileTest {
+    @Test
+    void catch_file_calls_with_typed_alternatives() {
+        test("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    // BUG: Diagnostic contains: GradleTestTypedFile
+                    dir.file("config.yml");
+                    // BUG: Diagnostic contains: GradleTestTypedFile
+                    dir.file("config.yaml");
+                    // BUG: Diagnostic contains: GradleTestTypedFile
+                    dir.file("build.gradle");
+                    // BUG: Diagnostic contains: GradleTestTypedFile
+                    dir.file("gradle.properties");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void catch_chained_directory_file() {
+        test("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    // BUG: Diagnostic contains: GradleTestTypedFile
+                    dir.directory("foo").file("bar.yml");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void catch_instances_inside_nested_classes() {
+        test("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+            import org.junit.jupiter.api.Nested;
+
+            @GradlePluginTests
+            class TestClass {
+                @Nested
+                class NestedClass {
+                    void test(Directory dir) {
+                        // BUG: Diagnostic contains: GradleTestTypedFile
+                        dir.file("config.yml");
+                    }
+                }
+            }
+            """);
+    }
+
+    @Test
+    void allow_file_calls_without_typed_alternatives() {
+        test("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.file("readme.txt");
+                    dir.file("data.json");
+                    dir.file("foo.gradle.kts");
+                    dir.file("config.xml");
+                    dir.file("notes.md");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void allow_file_calls_with_variable_arguments() {
+        test("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    String filename = "config.yml";
+                    dir.file(filename);
+                }
+            }
+            """);
+    }
+
+    @Test
+    void allow_file_calls_outside_gradle_plugin_tests() {
+        test("""
+            import com.palantir.gradle.testing.files.Directory;
+
+            class TestClass {
+                void test(Directory dir) {
+                    dir.file("config.yml");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_yml_extension() {
+        testFix("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.file("config.yml");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.yamlFile("config.yml");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_yaml_extension() {
+        testFix("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.file("config.yaml");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.yamlFile("config.yaml");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_gradle_extension() {
+        testFix("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.file("build.gradle");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.gradleFile("build.gradle");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_properties_extension() {
+        testFix("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.file("gradle.properties");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.propertiesFile("gradle.properties");
+                }
+            }
+            """);
+    }
+
+    @Test
+    void autofix_chained_directory_file() {
+        testFix("""
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.directory("foo").file("bar.yml");
+                }
+            }
+            """, """
+            import com.palantir.gradle.testing.files.Directory;
+            import com.palantir.gradle.testing.junit.GradlePluginTests;
+
+            @GradlePluginTests
+            class TestClass {
+                void test(Directory dir) {
+                    dir.directory("foo").yamlFile("bar.yml");
+                }
+            }
+            """);
+    }
+
+    private void test(@Language("Java") String javaCode) {
+        CompilationTestHelper.newInstance(GradleTestTypedFile.class, getClass())
+                .addSourceLines("TestClass.java", javaCode)
+                .doTest();
+    }
+
+    private void testFix(@Language("Java") String input, @Language("Java") String expected) {
+        BugCheckerRefactoringTestHelper.newInstance(GradleTestTypedFile.class, getClass())
+                .addInputLines("TestClass.java", input)
+                .addOutputLines("TestClass.java", expected)
+                .doTest();
+    }
+}


### PR DESCRIPTION
## Before this PR

When using the `gradle-plugin-testing` framework, it's easy to use `.file("config.yml")` instead of `.yamlFile("config.yml")`. The generic `.file()` method returns `ArbitraryFile` which has no `@Language` annotations, so IDE syntax highlighting doesn't work for the file contents. This was spotted in [hotfix-autopromotion-plugin PR #50](https://github.palantir.build/gradle-plugins/hotfix-autopromotion-plugin/pull/50) where `.file("autorelease.yml")` was used instead of `.yamlFile("autorelease.yml")`.

## After this PR

==CHANGELOG_MSG==
Add `GradleTestTypedFile` Error Prone check that flags `.file()` calls on `Directory` types when a typed alternative exists, and auto-fixes them.
==CHANGELOG_MSG==

A new `GradleTestTypedFile` Error Prone check flags `.file("name.ext")` calls on `Directory` types when the file extension has a typed alternative method that provides `@Language` annotations for IDE syntax highlighting:

| Extension | Suggested method |
|---|---|
| `.yml`, `.yaml` | `.yamlFile()` |
| `.gradle` | `.gradleFile()` |
| `.properties` | `.propertiesFile()` |

The check:
- Only fires within `@GradlePluginTests`-annotated classes
- Only matches string literal arguments (skips variables)
- Provides an auto-fix that replaces the method name
- Does not flag extensions without typed alternatives (`.txt`, `.json`, `.gradle.kts`, etc.)

## Possible downsides?

## Testing

- Positive tests: all four extension types flagged, chained directory calls, nested classes
- Negative tests: unknown extensions, non-literal args, outside `@GradlePluginTests`, `.gradle.kts`
- Auto-fix tests: all extension types + chained calls verified with `BugCheckerRefactoringTestHelper`