### PR TITLE
[PropertiesFile] SetProperty adds/updates property value

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -505,16 +505,16 @@ Manage `gradle.properties` and other properties files.  Use `appendProperty(key,
 void set_gradle_properties(RootProject project) {
     // Use appendProperty for key-value pairs
     project.gradlePropertiesFile()
-        .appendProperty("org.gradle.parallel", "true")
-        .appendProperty("org.gradle.caching", "true");
+        .setProperty("org.gradle.parallel", "true")
+        .setProperty("org.gradle.caching", "true");
 }
 
 @Test
 void create_versions_props(RootProject project) {
     // Use propertiesFile() for arbitrary properties files
     project.propertiesFile("versions.props")
-        .appendProperty("com.google.guava:*", "32.1.0-jre")
-        .appendProperty("org.slf4j:*", "2.0.9");
+        .setProperty("com.google.guava:*", "32.1.0-jre")
+        .setProperty("org.slf4j:*", "2.0.9");
 }
 ```
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -30,7 +30,11 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     public PropertiesFile {}
 
     public PropertiesFile appendProperty(String key, String value) {
-        return appendLine("%s=%s", key, value);
+        String propertyValue = String.format("%s=%s", key, value);
+        if (!text().contains(propertyValue)) {
+            return appendLine("%s=%s", key, value);
+        }
+        return this;
     }
 
     @Override

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -32,18 +32,18 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
     public PropertiesFile {}
 
+    /**
+     * Sets the property key to the {@code value} in the file.
+     */
     public PropertiesFile appendProperty(String key, String value) {
-        String text = Files.exists(path()) ? text() : "";
-        Matcher matcher = getPropertyMatcher(text, key);
+        String originalText = Files.exists(path()) ? text() : "";
+        Matcher matcher = getPropertyMatcher(originalText, key);
         if (!matcher.find()) {
             return appendLine("%s=%s", key, value);
         }
         String existingValue = matcher.group(1);
-        if (!existingValue.equals(value)) {
-            throw new IllegalArgumentException(
-                    String.format("Property '%s' already exists with a different value: '%s'", key, existingValue));
-        }
-        return this;
+        return edit(
+                text -> text.replace(String.format("%s=%s", key, existingValue), String.format("%s=%s", key, value)));
     }
 
     private Matcher getPropertyMatcher(String text, String key) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -22,6 +22,8 @@ import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.files.ProjectFile;
 import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.intellij.lang.annotations.Language;
 import org.intellij.lang.annotations.PrintFormat;
 
@@ -30,9 +32,16 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     public PropertiesFile {}
 
     public PropertiesFile appendProperty(String key, String value) {
-        String propertyValue = String.format("%s=%s", key, value);
-        if (!text().contains(propertyValue)) {
+        String regex = String.format("(?m)^%s=(.*)$", Pattern.quote(key));
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(text());
+        if (!matcher.find()) {
             return appendLine("%s=%s", key, value);
+        }
+        String existingValue = matcher.group(1);
+        if (!existingValue.equals(value)) {
+            throw new IllegalArgumentException(
+                    String.format("Property '%s' already exists with a different value: '%s'", key, existingValue));
         }
         return this;
     }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -21,7 +21,6 @@ import com.google.errorprone.annotations.FormatString;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.files.ProjectFile;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,15 +44,16 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
      * or appending a new property line if it does not.
      */
     public PropertiesFile setProperty(String key, String value) {
-        String originalText = Files.exists(path()) ? text() : "";
-        Matcher matcher = getPropertyMatcher(originalText, key);
-        if (!matcher.find()) {
-            return appendLine("%s=%s", key, value);
-        }
-        String existingValue = matcher.group(1);
-        return edit(text -> text.replaceFirst(
-                String.format("(?m)^%s=%s$", Pattern.quote(key), Pattern.quote(existingValue)),
-                String.format("%s=%s", key, value)));
+        return edit(text -> {
+            Matcher matcher = getPropertyMatcher(text, key);
+            if (!matcher.find()) {
+                return text + String.format("%s=%s\n", key, value);
+            }
+            String existingValue = matcher.group(1);
+            return text.replaceFirst(
+                    String.format("(?m)^%s=%s$", Pattern.quote(key), Pattern.quote(existingValue)),
+                    String.format("%s=%s", key, value));
+        });
     }
 
     private Matcher getPropertyMatcher(String text, String key) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -33,9 +33,18 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     public PropertiesFile {}
 
     /**
-     * Sets the property key to the {@code value} in the file.
+     * @deprecated Use {@link #setProperty(String, String)} instead.
      */
+    @Deprecated
     public PropertiesFile appendProperty(String key, String value) {
+        return setProperty(key, value);
+    }
+
+    /**
+     * Sets the property {@code key} to the given {@code value}, replacing the existing value if the key already exists,
+     * or appending a new property line if it does not.
+     */
+    public PropertiesFile setProperty(String key, String value) {
         String originalText = Files.exists(path()) ? text() : "";
         Matcher matcher = getPropertyMatcher(originalText, key);
         if (!matcher.find()) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -42,13 +42,13 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
             return appendLine("%s=%s", key, value);
         }
         String existingValue = matcher.group(1);
-        return edit(
-                text -> text.replace(String.format("%s=%s", key, existingValue), String.format("%s=%s", key, value)));
+        return edit(text -> text.replaceFirst(
+                String.format("(?m)^%s=%s$", Pattern.quote(key), Pattern.quote(existingValue)),
+                String.format("%s=%s", key, value)));
     }
 
     private Matcher getPropertyMatcher(String text, String key) {
-        String regex = String.format("(?m)^%s=(.*)$", Pattern.quote(key));
-        Pattern pattern = Pattern.compile(regex);
+        Pattern pattern = Pattern.compile(String.format("(?m)^%s=(.*)$", Pattern.quote(key)));
         return pattern.matcher(text);
     }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/properties/PropertiesFile.java
@@ -21,6 +21,7 @@ import com.google.errorprone.annotations.FormatString;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.files.ProjectFile;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,9 +33,8 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
     public PropertiesFile {}
 
     public PropertiesFile appendProperty(String key, String value) {
-        String regex = String.format("(?m)^%s=(.*)$", Pattern.quote(key));
-        Pattern pattern = Pattern.compile(regex);
-        Matcher matcher = pattern.matcher(text());
+        String text = Files.exists(path()) ? text() : "";
+        Matcher matcher = getPropertyMatcher(text, key);
         if (!matcher.find()) {
             return appendLine("%s=%s", key, value);
         }
@@ -44,6 +44,12 @@ public record PropertiesFile(Path path) implements ProjectFile<PropertiesFile> {
                     String.format("Property '%s' already exists with a different value: '%s'", key, existingValue));
         }
         return this;
+    }
+
+    private Matcher getPropertyMatcher(String text, String key) {
+        String regex = String.format("(?m)^%s=(.*)$", Pattern.quote(key));
+        Pattern pattern = Pattern.compile(regex);
+        return pattern.matcher(text);
     }
 
     @Override

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
@@ -1,0 +1,57 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.files.gradle;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import com.palantir.gradle.testing.files.properties.PropertiesFile;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class PropertiesFileTest {
+    PropertiesFile propertiesFile;
+
+    @BeforeEach
+    void beforeEach(@TempDir Path tempDir) {
+        propertiesFile = new PropertiesFile(tempDir.resolve("gradle.properties")).createEmpty();
+    }
+
+    @Test
+    void can_append_properties() {
+        propertiesFile.appendProperty("some.value", "true");
+        propertiesFile.appendProperty("other.value", "true");
+        propertiesFile.assertThat().hasContent("""
+            some.value=true
+            other.value=true
+            """);
+
+        assertThatThrownBy(() -> propertiesFile.appendProperty("other.value", "false"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Property 'other.value' already exists with a different value: 'true'");
+
+        propertiesFile.appendProperty("some.value", "true");
+        propertiesFile.assertThat().hasContent("""
+            some.value=true
+            other.value=true
+            """);
+
+        assertThatThrownBy(() -> propertiesFile.appendProperty("some.value", "false"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Property 'some.value' already exists with a different value: 'true'");
+    }
+}

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
@@ -32,29 +32,29 @@ public class PropertiesFileTest {
 
     @Test
     void can_append_properties() {
-        propertiesFile.appendProperty("some.value", "true");
-        propertiesFile.appendProperty("other.value", "true");
+        propertiesFile.setProperty("some.value", "true");
+        propertiesFile.setProperty("other.value", "true");
         propertiesFile.assertThat().hasContent("""
             some.value=true
             other.value=true
             """);
 
-        propertiesFile.appendProperty("some.other.value", "true");
-        propertiesFile.appendProperty("other.value", "false");
+        propertiesFile.setProperty("some.other.value", "true");
+        propertiesFile.setProperty("other.value", "false");
         propertiesFile.assertThat().hasContent("""
             some.value=true
             other.value=false
             some.other.value=true
             """);
 
-        propertiesFile.appendProperty("some.value", "true");
+        propertiesFile.setProperty("some.value", "true");
         propertiesFile.assertThat().hasContent("""
             some.value=true
             other.value=false
             some.other.value=true
             """);
 
-        propertiesFile.appendProperty("some.value", "false");
+        propertiesFile.setProperty("some.value", "false");
         propertiesFile.assertThat().hasContent("""
             some.value=false
             other.value=false

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.testing.files.gradle;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.palantir.gradle.testing.files.properties.PropertiesFile;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
@@ -39,22 +39,26 @@ public class PropertiesFileTest {
             other.value=true
             """);
 
+        propertiesFile.appendProperty("some.other.value", "true");
         propertiesFile.appendProperty("other.value", "false");
         propertiesFile.assertThat().hasContent("""
             some.value=true
             other.value=false
+            some.other.value=true
             """);
 
         propertiesFile.appendProperty("some.value", "true");
         propertiesFile.assertThat().hasContent("""
             some.value=true
             other.value=false
+            some.other.value=true
             """);
 
         propertiesFile.appendProperty("some.value", "false");
         propertiesFile.assertThat().hasContent("""
             some.value=false
             other.value=false
+            some.other.value=true
             """);
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/files/gradle/PropertiesFileTest.java
@@ -16,8 +16,6 @@
 
 package com.palantir.gradle.testing.files.gradle;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.palantir.gradle.testing.files.properties.PropertiesFile;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,18 +39,22 @@ public class PropertiesFileTest {
             other.value=true
             """);
 
-        assertThatThrownBy(() -> propertiesFile.appendProperty("other.value", "false"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Property 'other.value' already exists with a different value: 'true'");
+        propertiesFile.appendProperty("other.value", "false");
+        propertiesFile.assertThat().hasContent("""
+            some.value=true
+            other.value=false
+            """);
 
         propertiesFile.appendProperty("some.value", "true");
         propertiesFile.assertThat().hasContent("""
             some.value=true
-            other.value=true
+            other.value=false
             """);
 
-        assertThatThrownBy(() -> propertiesFile.appendProperty("some.value", "false"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Property 'some.value' already exists with a different value: 'true'");
+        propertiesFile.appendProperty("some.value", "false");
+        propertiesFile.assertThat().hasContent("""
+            some.value=false
+            other.value=false
+            """);
     }
 }

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -37,7 +37,7 @@ class PluginTestingJunitPluginTest {
     void beforeEach(RootProject rootProject) {
         rootProject
                 .gradlePropertiesFile()
-                .appendProperty(PluginTestingPlugin.PLUGIN_VERSION_PROPERTY_NAME, System.getProperty("projectVersion"));
+                .setProperty(PluginTestingPlugin.PLUGIN_VERSION_PROPERTY_NAME, System.getProperty("projectVersion"));
 
         rootProject
                 .buildGradle()
@@ -81,7 +81,7 @@ class PluginTestingJunitPluginTest {
             }
             """);
 
-        rootProject.propertiesFile("versions.props").appendProperty("com.palantir.sls-packaging:*", "7.84.0");
+        rootProject.propertiesFile("versions.props").setProperty("com.palantir.sls-packaging:*", "7.84.0");
 
         rootProject.testSourceSet().java().writeClass("""
             package test;
@@ -119,7 +119,7 @@ class PluginTestingJunitPluginTest {
             }
             """);
 
-        rootProject.propertiesFile("versions.props").appendProperty("com.palantir.sls-packaging:*", "7.84.0");
+        rootProject.propertiesFile("versions.props").setProperty("com.palantir.sls-packaging:*", "7.84.0");
 
         gradleInvoker.withArgs("writeVersionsLock").buildsSuccessfully();
         rootProject

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTaskTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/TestDependencyVersionsTaskTest.java
@@ -34,7 +34,7 @@ class TestDependencyVersionsTaskTest {
 
         rootProject
                 .gradlePropertiesFile()
-                .appendProperty(PluginTestingPlugin.PLUGIN_VERSION_PROPERTY_NAME, System.getProperty("projectVersion"));
+                .setProperty(PluginTestingPlugin.PLUGIN_VERSION_PROPERTY_NAME, System.getProperty("projectVersion"));
     }
 
     @Test
@@ -112,14 +112,14 @@ class TestDependencyVersionsTaskTest {
             """);
 
         project.propertiesFile("versions.props")
-                .appendProperty(
+                .setProperty(
                         "org.junit.jupiter:junit-jupiter",
                         TestDependencyVersions.version("org.junit.jupiter:junit-jupiter"))
-                .appendProperty(
+                .setProperty(
                         "com.netflix.nebula:nebula-test",
                         TestDependencyVersions.version("com.netflix.nebula:nebula-test"))
-                .appendProperty("com.google.guava:guava", TestDependencyVersions.version("com.google.guava:guava"))
-                .appendProperty(
+                .setProperty("com.google.guava:guava", TestDependencyVersions.version("com.google.guava:guava"))
+                .setProperty(
                         "com.palantir.gradle.consistentversions:gradle-consistent-versions",
                         TestDependencyVersions.version(
                                 "com.palantir.gradle.consistentversions:gradle-consistent-versions"));

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,3 @@ org.gradle.caching = true
 org.gradle.jvmargs = --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 palantir.jdk.setup.enabled=true
 palantir.native.formatter=true
-palantir.native.formatter=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ org.gradle.caching = true
 org.gradle.jvmargs = --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 palantir.jdk.setup.enabled=true
 palantir.native.formatter=true
+palantir.native.formatter=false


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Required by https://github.com/palantir/gradle-jdks/pull/661/changes#r2712867634. `setProperty` sets the property to the given value, replacing the existing value if the key already exists, or appending a new property line if it does not.

==COMMIT_MSG==
[PropertiesFile] appendProperty de-dups & checks values
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

