### PR TITLE
Add `testingEnvironmentVariables` Option

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -717,7 +717,7 @@ public void someMethod() {
 }
 ```
 
-In your tests, pass extra testing environment variables via the `Options` builder. These will be automatically configured for use with `EnvironmentVariables`:
+In your tests, pass extra testing environment variables via the `Options` builder. These will be automatically configured for use with [`EnvironmentVariables`](https://github.com/palantir/gradle-utils?tab=readme-ov-file#environmentvariables):
 
 ```java
 @Test

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -700,15 +700,18 @@ public void someMethod() {
 }
 ```
 
-In your tests, pass values via Gradle properties:
+In your tests, pass extra testing environment variables via the Options builder. These will be automatically configured for use with `EnvironmentVariables`"
 
 ```java
 @Test
 void plugin_reads_environment_variable(GradleInvoker gradle, RootProject project) {
     project.buildGradle().plugins().add("my-plugin");
 
-    gradle.withArgs("myTask", "-P__TESTING=true", "-P__TESTING_FOO=TEST_VALUE")
-        .buildsSuccessfully();
+    gradle.with(Options.builder()
+                    .addArgs("myTask")
+                    .putTestingEnvironmentVariables("FOO", "TEST_VALUE")
+                    .build())
+            .buildsSuccessfully();
 }
 ```
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -659,6 +659,23 @@ void successful_build(GradleInvoker gradle, RootProject project) {
 }
 ```
 
+For more complex logic (eg. adding both arguments and testing environment variables), use `gradle.with(Options)`:
+
+```java
+import com.palantir.gradle.testing.execution.Options;
+
+@Test  
+void build_with_options(GradleInvoker gradle, RootProject project) {
+    project.buildGradle().plugins().add("java");
+
+    gradle.with(Options.builder()
+            .addArgs("build", "--info")
+            .putTestingEnvironmentVariables("FOO", "test_value")
+            .build())
+        .buildsSuccessfully();
+}
+```
+
 ### Running builds with Configuration Cache enabled
 
 When [`configuration cache is enabled (getConfigurationCacheEnabled() == true)`](../gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingExtension.java), each GradleInvoker invocation will automatically run twice:
@@ -700,7 +717,7 @@ public void someMethod() {
 }
 ```
 
-In your tests, pass extra testing environment variables via the Options builder. These will be automatically configured for use with `EnvironmentVariables`"
+In your tests, pass extra testing environment variables via the `Options` builder. These will be automatically configured for use with `EnvironmentVariables`:
 
 ```java
 @Test

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -38,6 +38,9 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
                         .addAll(options.args())
                         .add("--stacktrace")
                         .add("-P__TESTING=true")
+                        .addAll(options.testingEnvironmentVariables().entrySet().stream()
+                                .map(e -> String.format("-P__TESTING_%s=%s", e.getKey(), e.getValue()))
+                                .toList())
                         .build());
 
         return new DefaultGradleInvocation(runner);

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
@@ -121,7 +121,7 @@ public interface GradleInvoker {
             DecoratorContext context, GradleInvoker baseInvoker, Set<Annotation> annotations) {
 
         ListMultimap<Class<? extends GradleInvokerDecorator>, Annotation> decoratorToAnnotations =
-                MultimapBuilder.hashKeys().arrayListValues().build();
+                MultimapBuilder.linkedHashKeys().arrayListValues().build();
         for (Annotation annotation : annotations) {
             RegistersGradleInvokerDecorator registersMeta =
                     annotation.annotationType().getAnnotation(RegistersGradleInvokerDecorator.class);

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/Options.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/Options.java
@@ -27,7 +27,7 @@ public abstract class Options {
 
     public abstract List<String> args();
 
-    public abstract Map<String, Object> testingEnvironmentVariables();
+    public abstract Map<String, String> testingEnvironmentVariables();
 
     public final Builder asBuilder() {
         return builder().from(this);

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/Options.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/Options.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.testing.execution;
 
 import com.palantir.gradle.testing.ImmutablesStyle;
 import java.util.List;
+import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -25,6 +26,8 @@ import org.immutables.value.Value;
 public abstract class Options {
 
     public abstract List<String> args();
+
+    public abstract Map<String, Object> testingEnvironmentVariables();
 
     public final Builder asBuilder() {
         return builder().from(this);

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/TestingPropertiesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/TestingPropertiesTest.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.integration;
+
+import com.palantir.gradle.testing.execution.GradleInvoker;
+import com.palantir.gradle.testing.execution.Options;
+import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.RootProject;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+@GradlePluginTests
+public class TestingPropertiesTest {
+
+    @Test
+    void root_project_parameter(GradleInvoker gradle, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+            println "hello from ${project.property("__TESTING_FOO")}"
+            """);
+
+        Options fooOptions = Options.builder()
+                .testingEnvironmentVariables(Map.of("FOO", "foo"))
+                .build();
+        gradle.with(fooOptions).buildsSuccessfully().assertThat().output().contains("hello from foo");
+
+        Options barOptions = fooOptions
+                .asBuilder()
+                .putTestingEnvironmentVariables("FOO", "bar")
+                .build();
+        gradle.with(barOptions).buildsSuccessfully().assertThat().output().contains("hello from bar");
+    }
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
No ootb support for [testing environment variables](https://github.com/palantir/gradle-utils?tab=readme-ov-file#environmentvariables).

## After this PR
Support for adding `testingEnvironmentVariables` as parameters to `Options`
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `testingEnvironmentVariables` Option
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

