### PR TITLE
Discover test classes from all source sets, not just `test`

### DIFF
--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -201,9 +201,12 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
 
         project.getTasks().withType(DiscoverTestClassesTask.class, task -> {
             SourceSetContainer sourceSetContainer = project.getExtensions().getByType(SourceSetContainer.class);
-            SourceSet testSourceSet = sourceSetContainer.getByName(SourceSet.TEST_SOURCE_SET_NAME);
-            task.getTestClasspath().setFrom(testSourceSet.getRuntimeClasspath());
-            task.getTestSourceFiles().setFrom(testSourceSet.getAllSource());
+            sourceSetContainer.all(sourceSet -> {
+                if (!sourceSet.getName().equals(SourceSet.MAIN_SOURCE_SET_NAME)) {
+                    task.getTestClasspath().from(sourceSet.getRuntimeClasspath());
+                    task.getTestSourceFiles().from(sourceSet.getAllSource());
+                }
+            });
             task.getRootPath().set(project.getRootProject().getProjectDir());
         });
     }

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -333,34 +333,34 @@ class PluginTestingJunitPluginTest {
     void nebula_tests_in_both_test_and_integrationTest_source_sets_are_discovered(
             GradleInvoker gradle, RootProject rootProject) throws IOException {
         rootProject.buildGradle().append("""
-                sourceSets {
-                    integrationTest {
-                        groovy.srcDirs = ['src/integrationTest/groovy']
-                        compileClasspath += sourceSets.test.compileClasspath
-                        runtimeClasspath += sourceSets.test.runtimeClasspath
-                    }
+            sourceSets {
+                integrationTest {
+                    groovy.srcDirs = ['src/integrationTest/groovy']
+                    compileClasspath += sourceSets.test.compileClasspath
+                    runtimeClasspath += sourceSets.test.runtimeClasspath
                 }
-                """);
+            }
+            """);
 
         Directory testGroovyDir =
                 rootProject.testSourceSet().srcDir("groovy").directory("test").createDirectories();
 
         testGroovyDir.file("TestSourceSetSpec.groovy").overwrite("""
-                package test;
+            package test;
 
-                import nebula.test.IntegrationSpec
-                import java.nio.file.Files;
+            import nebula.test.IntegrationSpec
+            import java.nio.file.Files;
 
-                class TestSourceSetSpec extends IntegrationSpec {
+            class TestSourceSetSpec extends IntegrationSpec {
 
-                    def '#param: my test'() {
-                        Files.createTempDirectory("prefix" + gradleVersion);
+                def '#param: my test'() {
+                    Files.createTempDirectory("prefix" + gradleVersion);
 
-                        where:
-                        param << [1, 2]
-                    }
+                    where:
+                    param << [1, 2]
                 }
-                """);
+            }
+            """);
 
         Directory integrationGroovyDir = rootProject
                 .sourceSet("integrationTest")
@@ -369,21 +369,21 @@ class PluginTestingJunitPluginTest {
                 .createDirectories();
 
         integrationGroovyDir.file("IntegrationSourceSetSpec.groovy").overwrite("""
-                package test;
+            package test;
 
-                import nebula.test.IntegrationSpec
-                import java.nio.file.Files;
+            import nebula.test.IntegrationSpec
+            import java.nio.file.Files;
 
-                class IntegrationSourceSetSpec extends IntegrationSpec {
+            class IntegrationSourceSetSpec extends IntegrationSpec {
 
-                    def '#param: my test'() {
-                        Files.createTempDirectory("prefix" + gradleVersion);
+                def '#param: my test'() {
+                    Files.createTempDirectory("prefix" + gradleVersion);
 
-                        where:
-                        param << [1, 2]
-                    }
+                    where:
+                    param << [1, 2]
                 }
-                """);
+            }
+            """);
 
         gradle.withArgs("discoverNebulaTestClassesToMigrate").buildsSuccessfully();
         assertThat(readTestClassesPaths(rootProject, "groovy"))

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -330,17 +330,37 @@ class PluginTestingJunitPluginTest {
     }
 
     @Test
-    void nebula_tests_in_non_test_source_sets_are_discovered(GradleInvoker gradle, RootProject rootProject)
-            throws IOException {
+    void nebula_tests_in_both_test_and_integrationTest_source_sets_are_discovered(
+            GradleInvoker gradle, RootProject rootProject) throws IOException {
         rootProject.buildGradle().append("""
-            sourceSets {
-                integrationTest {
-                    groovy.srcDirs = ['src/integrationTest/groovy']
-                    compileClasspath += sourceSets.test.compileClasspath
-                    runtimeClasspath += sourceSets.test.runtimeClasspath
+                sourceSets {
+                    integrationTest {
+                        groovy.srcDirs = ['src/integrationTest/groovy']
+                        compileClasspath += sourceSets.test.compileClasspath
+                        runtimeClasspath += sourceSets.test.runtimeClasspath
+                    }
                 }
-            }
-            """);
+                """);
+
+        Directory testGroovyDir =
+                rootProject.testSourceSet().srcDir("groovy").directory("test").createDirectories();
+
+        testGroovyDir.file("TestSourceSetSpec.groovy").overwrite("""
+                package test;
+
+                import nebula.test.IntegrationSpec
+                import java.nio.file.Files;
+
+                class TestSourceSetSpec extends IntegrationSpec {
+
+                    def '#param: my test'() {
+                        Files.createTempDirectory("prefix" + gradleVersion);
+
+                        where:
+                        param << [1, 2]
+                    }
+                }
+                """);
 
         Directory integrationGroovyDir = rootProject
                 .sourceSet("integrationTest")
@@ -348,26 +368,28 @@ class PluginTestingJunitPluginTest {
                 .directory("test")
                 .createDirectories();
 
-        integrationGroovyDir.file("IntegrationSourceSetTest.groovy").overwrite("""
-            package test;
+        integrationGroovyDir.file("IntegrationSourceSetSpec.groovy").overwrite("""
+                package test;
 
-            import nebula.test.IntegrationSpec
-            import java.nio.file.Files;
+                import nebula.test.IntegrationSpec
+                import java.nio.file.Files;
 
-            class IntegrationSourceSetTest extends IntegrationSpec {
+                class IntegrationSourceSetSpec extends IntegrationSpec {
 
-                def '#param: my test'() {
-                    Files.createTempDirectory("prefix" + gradleVersion);
+                    def '#param: my test'() {
+                        Files.createTempDirectory("prefix" + gradleVersion);
 
-                    where:
-                    param << [1, 2]
+                        where:
+                        param << [1, 2]
+                    }
                 }
-            }
-            """);
+                """);
 
         gradle.withArgs("discoverNebulaTestClassesToMigrate").buildsSuccessfully();
         assertThat(readTestClassesPaths(rootProject, "groovy"))
-                .containsExactlyInAnyOrder("src/integrationTest/groovy/test/IntegrationSourceSetTest.groovy");
+                .containsExactlyInAnyOrder(
+                        "src/test/groovy/test/TestSourceSetSpec.groovy",
+                        "src/integrationTest/groovy/test/IntegrationSourceSetSpec.groovy");
     }
 
     private static List<String> readTestClassesPaths(RootProject rootProject, String language) throws IOException {

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -329,6 +329,47 @@ class PluginTestingJunitPluginTest {
                         "src/test/groovy/test/ConfigurationCacheTest.groovy");
     }
 
+    @Test
+    void nebula_tests_in_non_test_source_sets_are_discovered(GradleInvoker gradle, RootProject rootProject)
+            throws IOException {
+        rootProject.buildGradle().append("""
+            sourceSets {
+                integrationTest {
+                    groovy.srcDirs = ['src/integrationTest/groovy']
+                    compileClasspath += sourceSets.test.compileClasspath
+                    runtimeClasspath += sourceSets.test.runtimeClasspath
+                }
+            }
+            """);
+
+        Directory integrationGroovyDir = rootProject
+                .sourceSet("integrationTest")
+                .srcDir("groovy")
+                .directory("test")
+                .createDirectories();
+
+        integrationGroovyDir.file("IntegrationSourceSetTest.groovy").overwrite("""
+            package test;
+
+            import nebula.test.IntegrationSpec
+            import java.nio.file.Files;
+
+            class IntegrationSourceSetTest extends IntegrationSpec {
+
+                def '#param: my test'() {
+                    Files.createTempDirectory("prefix" + gradleVersion);
+
+                    where:
+                    param << [1, 2]
+                }
+            }
+            """);
+
+        gradle.withArgs("discoverNebulaTestClassesToMigrate").buildsSuccessfully();
+        assertThat(readTestClassesPaths(rootProject, "groovy"))
+                .containsExactlyInAnyOrder("src/integrationTest/groovy/test/IntegrationSourceSetTest.groovy");
+    }
+
     private static List<String> readTestClassesPaths(RootProject rootProject, String language) throws IOException {
         return Files.readAllLines(rootProject
                 .buildDir()


### PR DESCRIPTION
## Before this PR

`DiscoverTestClassesTask` was only configured with the `test` source set's classpath and source files. Tests in other source sets like `integrationTest` were never discovered by tasks like `discoverNebulaTestClassesToMigrate` or `discoverGradlePluginTestsWithDisabledConfigurationCache`.

## After this PR

`addTestClassesDiscoveryTasks` now iterates all non-main source sets via `sourceSetContainer.all()`, so discovery tasks find tests in `integrationTest` and any other custom source sets. Using `all()` also handles source sets added by plugins that apply after ours.

## Possible downsides?

Source sets unrelated to testing will have their files included in the discovery scan. This shouldn't cause issues since those source sets won't contain nebula test classes or `@DisabledConfigurationCache` annotations — they'll just add files to the classpath without affecting discovery results.

## Test plan

- New test `nebula_tests_in_non_test_source_sets_are_discovered` creates an `integrationTest` source set with a nebula test class and verifies it's discovered
- Existing tests continue to pass