### PR TITLE
[junit-migration-excavator-instructions] Add "initial-rollout" reason for DisabledCC annotation

### DIFF
--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -67,7 +67,7 @@ These comments should be copied over to the new test files as they are created t
 
 # General Instructions
 - You MUST migrate ALL tests from the original file. Do not skip any tests or only migrate a "representative sample". Every single test method in the original Groovy file must have a corresponding test method in the new Java file.
-- Always add both `@GradlePluginTests` and `@DisabledConfigurationCache` to the migrated test classes.
+- Always add both `@GradlePluginTests` and `@DisabledConfigurationCache("initial-rollout")` to the current migrated test class.
 - Test names should be changed to a snake_case_english_sentence in all lower case.
 - Keep the comments from the original Groovy tests when writing the new tests.
 - Method name mappings from old to new framework:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
[junit-migration-excavator-instructions] Add "initial-rollout" reason for DisabledCC annotation
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

