### PR TITLE
Add `customGradleUserHome` in `Options`

### DIFF
--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -42,6 +42,7 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
                                 .map(e -> String.format("-P__TESTING_%s=%s", e.getKey(), e.getValue()))
                                 .toList())
                         .build());
+        options.customGradleUserHome().ifPresent(gradleUserHome -> runner.withTestKitDir(gradleUserHome.toFile()));
 
         return new DefaultGradleInvocation(runner);
     }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/Options.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/Options.java
@@ -17,8 +17,10 @@
 package com.palantir.gradle.testing.execution;
 
 import com.palantir.gradle.testing.ImmutablesStyle;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -28,6 +30,8 @@ public abstract class Options {
     public abstract List<String> args();
 
     public abstract Map<String, String> testingEnvironmentVariables();
+
+    public abstract Optional<Path> customGradleUserHome();
 
     public final Builder asBuilder() {
         return builder().from(this);


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Default `gradleUserHome` directory set [here](https://github.com/gradle/gradle/blob/master/platforms/extensibility/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java#L85), shared by all tests (`<project>/build/tmp/test/work/.gradle-test-kit`)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Allowing GradlePluginTests to override the `gradleUserHome`. Required by gradle-jdks: https://github.com/palantir/gradle-jdks/pull/635/changes#diff-51800d21937c5a5e7382c93a573dfa6d4e33e4f2a1f2cde9f96e107ed8cfd003R42


==COMMIT_MSG==
Add `customGradleUserHome` in `Options`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

