### PR TITLE
Add `IncludedBuild` support for composite build testing

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -101,6 +101,7 @@ Tests can request these parameters in any order:
 - **`GradleInvoker`** - Executes Gradle builds
 - **`RootProject`** - Gradle root project that will always be named "root". To use a different project name, call `rootProject.settingsGradle().rootProjectName("custom-name")`
 - **`SubProject`** - Gradle subproject for the root project. The parameter name will be used as the project name exactly. For example, `SubProject apiService` creates a subproject named `apiService`
+- **`IncludedBuild`** - An included build (composite build) for the root project. The parameter name will be used as the build name exactly. For example, `IncludedBuild myLib` creates an included build named `myLib` with its own `settings.gradle` and `build.gradle`
 - **`MavenRepo`** - Maven repository for publishing test artifacts. See [Maven Repository Testing](#maven-repository-testing)
 
 These parameters can be used in the constructor for a test class or in `@Test`, `@BeforeEach`, `@AfterEach`, `@BeforeAll`, or `@AfterAll` methods.
@@ -127,6 +128,40 @@ void multi_project_build(SubProject api, SubProject server) {
 void create_nested_subprojects_manually(SubProject api) {
     // Nested subprojects
     SubProject nestedProject = api.subproject("nested");
+}
+```
+
+**Example with included builds (composite builds):**
+```java
+@Test
+void composite_build(GradleInvoker gradle, RootProject rootProject, IncludedBuild sharedLib) {
+    // "sharedLib" is automatically created as an included build with its own settings.gradle
+    sharedLib.buildGradle().plugins().add("java-library");
+
+    rootProject.buildGradle().plugins().add("java");
+    rootProject.buildGradle().append("""
+            dependencies {
+                implementation 'com.example:sharedLib'
+            }
+            """);
+
+    gradle.withArgs("tasks").buildsSuccessfully();
+}
+```
+
+**Creating included builds programmatically:**
+```java
+@Test
+void create_nested_included_build(IncludedBuild outerLib) {
+    outerLib.buildGradle().plugins().add("java-library");
+
+    // Included builds can contain their own included builds
+    IncludedBuild innerLib = outerLib.includedBuild("inner-lib");
+    innerLib.buildGradle().plugins().add("java-library");
+
+    // Included builds can also have their own subprojects
+    SubProject sub = outerLib.subproject("sub-module");
+    sub.buildGradle().plugins().add("java-library");
 }
 ```
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/RestrictedCreation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/RestrictedCreation.java
@@ -18,10 +18,10 @@ package com.palantir.gradle.testing;
 
 public final class RestrictedCreation {
     public static final String EXPLANATION =
-            "Use junit injected objects like GradleInvoker, RootProject or SubProject etc instead rather than "
-                    + "creating these manually. If there really isn't some way to do what you need through the "
-                    + "injected types, please contribute to palantir/gradle-plugin-testing rather than manually "
-                    + "working around the lack of functionality";
+            "Use junit injected objects like GradleInvoker, RootProject, SubProject or IncludedBuild etc instead"
+                    + " rather than creating these manually. If there really isn't some way to do what you need through"
+                    + " the injected types, please contribute to palantir/gradle-plugin-testing rather than manually"
+                    + " working around the lack of functionality";
 
     public static final String ALLOWED_ON_PATH = ".*/com/palantir/gradle/testing/.*";
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
@@ -72,14 +72,19 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
         // check if there is a configuration time error that isn't related to configuration cache errors or any script
         // exceptions
         if (result.output().contains("org.gradle.api.ProjectConfigurationException:")
-                || result.output().contains("org.gradle.api.GradleScriptException:")
-                || result.output().contains("which is the same as a project of the main build")) {
+                || result.output().contains("org.gradle.api.GradleScriptException:")) {
             return result;
         }
 
         assertConfigCacheStored(result);
-        InvocationResult configurationCacheResult = secondGradleInvocation.buildsSuccessfully();
-        assertConfigCacheReused(configurationCacheResult);
+        try {
+            InvocationResult configurationCacheResult = secondGradleInvocation.buildsSuccessfully();
+            assertConfigCacheReused(configurationCacheResult);
+        } catch (UnexpectedBuildFailure unexpectedBuildFailure) {
+            if (unexpectedBuildFailure.getBuildResult().getOutput().contains("configuration cache cannot be reused")) {
+                throwReuseFailure(new InvocationResult(unexpectedBuildFailure.getBuildResult()));
+            }
+        }
         return result;
     }
 
@@ -112,19 +117,23 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
 
     private void assertConfigCacheReused(InvocationResult result) {
         if (!result.output().contains("Configuration cache entry reused.")) {
-            throw new UnexpectedConfigurationCacheFailure(String.format("""
-                Configuration cache reuse failure: The second run failed to reuse the cached configuration.
-
-                This test runs with configuration cache enabled (`gradleTestUtils.configurationCacheEnabled=true`).
-                Test sequence:
-                    ✓ First run: Successfully executed tasks and stored configuration cache
-                    ✗ Second run: Failed to reuse configuration cache during dry-run verification
-
-                Please check the output below for specific configuration cache problems.
-
-                Output:
-                %s
-                """, result.output()), result);
+            throwReuseFailure(result);
         }
+    }
+
+    private static void throwReuseFailure(InvocationResult result) {
+        throw new UnexpectedConfigurationCacheFailure(String.format("""
+            Configuration cache reuse failure: The second run failed to reuse the cached configuration.
+
+            This test runs with configuration cache enabled (`gradleTestUtils.configurationCacheEnabled=true`).
+            Test sequence:
+                ✓ First run: Successfully executed tasks and stored configuration cache
+                ✗ Second run: Failed to reuse configuration cache during dry-run verification
+
+            Please check the output below for specific configuration cache problems.
+
+            Output:
+            %s
+            """, result.output()), result);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
@@ -72,7 +72,8 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
         // check if there is a configuration time error that isn't related to configuration cache errors or any script
         // exceptions
         if (result.output().contains("org.gradle.api.ProjectConfigurationException:")
-                || result.output().contains("org.gradle.api.GradleScriptException:")) {
+                || result.output().contains("org.gradle.api.GradleScriptException:")
+                || result.output().contains("which is the same as a project of the main build")) {
             return result;
         }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
@@ -81,7 +81,9 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
             InvocationResult configurationCacheResult = secondGradleInvocation.buildsSuccessfully();
             assertConfigCacheReused(configurationCacheResult);
         } catch (UnexpectedBuildFailure unexpectedBuildFailure) {
-            assertConfigCacheReused(new InvocationResult(unexpectedBuildFailure.getBuildResult()));
+            if (unexpectedBuildFailure.getBuildResult().getOutput().contains("configuration cache cannot be reused")) {
+                throwReuseFailure(new InvocationResult(unexpectedBuildFailure.getBuildResult()));
+            }
         }
         return result;
     }
@@ -115,19 +117,23 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
 
     private void assertConfigCacheReused(InvocationResult result) {
         if (!result.output().contains("Configuration cache entry reused.")) {
-            throw new UnexpectedConfigurationCacheFailure(String.format("""
-                Configuration cache reuse failure: The second run failed to reuse the cached configuration.
-
-                This test runs with configuration cache enabled (`gradleTestUtils.configurationCacheEnabled=true`).
-                Test sequence:
-                    ✓ First run: Successfully executed tasks and stored configuration cache
-                    ✗ Second run: Failed to reuse configuration cache during dry-run verification
-
-                Please check the output below for specific configuration cache problems.
-
-                Output:
-                %s
-                """, result.output()), result);
+            throwReuseFailure(result);
         }
+    }
+
+    private static void throwReuseFailure(InvocationResult result) {
+        throw new UnexpectedConfigurationCacheFailure(String.format("""
+            Configuration cache reuse failure: The second run failed to reuse the cached configuration.
+
+            This test runs with configuration cache enabled (`gradleTestUtils.configurationCacheEnabled=true`).
+            Test sequence:
+                ✓ First run: Successfully executed tasks and stored configuration cache
+                ✗ Second run: Failed to reuse configuration cache during dry-run verification
+
+            Please check the output below for specific configuration cache problems.
+
+            Output:
+            %s
+            """, result.output()), result);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/ConfigurationCacheInvocation.java
@@ -81,9 +81,7 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
             InvocationResult configurationCacheResult = secondGradleInvocation.buildsSuccessfully();
             assertConfigCacheReused(configurationCacheResult);
         } catch (UnexpectedBuildFailure unexpectedBuildFailure) {
-            if (unexpectedBuildFailure.getBuildResult().getOutput().contains("configuration cache cannot be reused")) {
-                throwReuseFailure(new InvocationResult(unexpectedBuildFailure.getBuildResult()));
-            }
+            assertConfigCacheReused(new InvocationResult(unexpectedBuildFailure.getBuildResult()));
         }
         return result;
     }
@@ -117,23 +115,19 @@ public final class ConfigurationCacheInvocation implements GradleInvocation {
 
     private void assertConfigCacheReused(InvocationResult result) {
         if (!result.output().contains("Configuration cache entry reused.")) {
-            throwReuseFailure(result);
+            throw new UnexpectedConfigurationCacheFailure(String.format("""
+                Configuration cache reuse failure: The second run failed to reuse the cached configuration.
+
+                This test runs with configuration cache enabled (`gradleTestUtils.configurationCacheEnabled=true`).
+                Test sequence:
+                    ✓ First run: Successfully executed tasks and stored configuration cache
+                    ✗ Second run: Failed to reuse configuration cache during dry-run verification
+
+                Please check the output below for specific configuration cache problems.
+
+                Output:
+                %s
+                """, result.output()), result);
         }
-    }
-
-    private static void throwReuseFailure(InvocationResult result) {
-        throw new UnexpectedConfigurationCacheFailure(String.format("""
-            Configuration cache reuse failure: The second run failed to reuse the cached configuration.
-
-            This test runs with configuration cache enabled (`gradleTestUtils.configurationCacheEnabled=true`).
-            Test sequence:
-                ✓ First run: Successfully executed tasks and stored configuration cache
-                ✗ Second run: Failed to reuse configuration cache during dry-run verification
-
-            Please check the output below for specific configuration cache problems.
-
-            Output:
-            %s
-            """, result.output()), result);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
@@ -25,6 +25,7 @@ import com.palantir.gradle.testing.junit.DecoratorContext;
 import com.palantir.gradle.testing.junit.GradleInvokerDecorator;
 import com.palantir.gradle.testing.junit.RegistersGradleInvokerDecorator;
 import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.TopLevelRootProject;
 import java.lang.annotation.Annotation;
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.AnnotatedElement;
@@ -54,7 +55,7 @@ public interface GradleInvoker {
 
     static GradleInvoker create(Path path, GradleVersion gradleVersion, ExtensionContext extensionContext) {
         GradleInvoker baseInvoker = getInternalDefaultInvoker(path, gradleVersion);
-        RootProject rootProject = new RootProject(path);
+        RootProject rootProject = new TopLevelRootProject(path);
         DecoratorContext decoratorContext = new DecoratorContext(rootProject, gradleVersion, extensionContext);
         Set<Annotation> annotations = collectAnnotationsFromContext(extensionContext);
         return decorateInvokerWithAnnotations(decoratorContext, baseInvoker, annotations);

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/SettingsGradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/SettingsGradleFile.java
@@ -48,20 +48,11 @@ public record SettingsGradleFile(Path path) implements GradleFile {
     }
 
     public SettingsGradleFile includeBuild(String buildPath) {
-        checkNoConflict(buildPath, "include '%s'".formatted(buildPath), "a subproject");
         return idempotentAppend("includeBuild '%s'".formatted(buildPath));
     }
 
     public SettingsGradleFile include(String projectPath) {
-        checkNoConflict(projectPath, "includeBuild '%s'".formatted(projectPath), "an included build");
         return idempotentAppend("include '%s'".formatted(projectPath));
-    }
-
-    private void checkNoConflict(String name, String conflictingLine, String conflictingType) {
-        if (Files.exists(path) && text().contains(conflictingLine)) {
-            throw new IllegalArgumentException(
-                    "'%s' is already registered as %s and cannot also be used here".formatted(name, conflictingType));
-        }
     }
 
     private SettingsGradleFile idempotentAppend(@Language("Gradle") String line) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/SettingsGradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/SettingsGradleFile.java
@@ -47,15 +47,20 @@ public record SettingsGradleFile(Path path) implements GradleFile {
         return this;
     }
 
-    public SettingsGradleFile include(String projectPath) {
-        @Language("Gradle")
-        String includeLine = "include '%s'".formatted(projectPath);
+    public SettingsGradleFile includeBuild(String buildPath) {
+        return idempotentAppend("includeBuild '%s'".formatted(buildPath));
+    }
 
-        if (Files.exists(path) && text().contains(includeLine)) {
+    public SettingsGradleFile include(String projectPath) {
+        return idempotentAppend("include '%s'".formatted(projectPath));
+    }
+
+    private SettingsGradleFile idempotentAppend(@Language("Gradle") String line) {
+        if (Files.exists(path) && text().contains(line)) {
             return this;
         }
 
-        appendLine(includeLine);
+        appendLine(line);
         return this;
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/SettingsGradleFile.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/files/gradle/SettingsGradleFile.java
@@ -48,11 +48,20 @@ public record SettingsGradleFile(Path path) implements GradleFile {
     }
 
     public SettingsGradleFile includeBuild(String buildPath) {
+        checkNoConflict(buildPath, "include '%s'".formatted(buildPath), "a subproject");
         return idempotentAppend("includeBuild '%s'".formatted(buildPath));
     }
 
     public SettingsGradleFile include(String projectPath) {
+        checkNoConflict(projectPath, "includeBuild '%s'".formatted(projectPath), "an included build");
         return idempotentAppend("include '%s'".formatted(projectPath));
+    }
+
+    private void checkNoConflict(String name, String conflictingLine, String conflictingType) {
+        if (Files.exists(path) && text().contains(conflictingLine)) {
+            throw new IllegalArgumentException(
+                    "'%s' is already registered as %s and cannot also be used here".formatted(name, conflictingType));
+        }
     }
 
     private SettingsGradleFile idempotentAppend(@Language("Gradle") String line) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/GradleProjectParameterResolver.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/GradleProjectParameterResolver.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.testing.junit;
 
+import com.palantir.gradle.testing.project.IncludedBuild;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.gradle.testing.project.SubProject;
 import java.util.Optional;
@@ -32,6 +33,11 @@ final class GradleProjectParameterResolver implements TerseParameterResolver {
         if (parameterContext.getParameter().getType().equals(SubProject.class)) {
             return Optional.of(rootProjectFor(extensionContext)
                     .subproject(parameterContext.getParameter().getName()));
+        }
+
+        if (parameterContext.getParameter().getType().equals(IncludedBuild.class)) {
+            return Optional.of(rootProjectFor(extensionContext)
+                    .includedBuild(parameterContext.getParameter().getName()));
         }
 
         return Optional.empty();

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/RootProjectStore.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/RootProjectStore.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.testing.junit;
 import com.google.common.collect.Lists;
 import com.palantir.gradle.testing.execution.GradleVersion;
 import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.TopLevelRootProject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -40,7 +41,7 @@ final class RootProjectStore {
     private static final Pattern INVALID_FILENAME_CHARS = Pattern.compile("[\\\\/:*?\"<>|\\x00-\\x1F]");
 
     public static RootProject rootProject(ExtensionContext extensionContext) {
-        return new RootProject(rootProjectDir(extensionContext));
+        return new TopLevelRootProject(rootProjectDir(extensionContext));
     }
 
     public static Path rootProjectDir(ExtensionContext context) {
@@ -63,7 +64,7 @@ final class RootProjectStore {
 
         clearDirectory(projectDir);
 
-        RootProject rootProject = new RootProject(projectDir);
+        RootProject rootProject = new TopLevelRootProject(projectDir);
         rootProject.settingsGradle().createEmpty();
         rootProject.settingsGradle().rootProjectName("root");
         rootProject.gradlePropertiesFile().setProperty("org.gradle.parallel", "true");

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepo.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepo.java
@@ -20,7 +20,7 @@ import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.GradleVersion;
-import com.palantir.gradle.testing.project.RootProject;
+import com.palantir.gradle.testing.project.TopLevelRootProject;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -61,7 +61,7 @@ public final class MavenRepo {
         Path repoDirPath = repoDir.resolve("localMavenRepositoryPublisherProject");
         this.publisher = new MavenRepoPublisher(
                 mavenRepoUrl,
-                new RootProject(repoDirPath),
+                new TopLevelRootProject(repoDirPath),
                 GradleInvoker.getInternalDefaultInvoker(repoDirPath, gradleVersion));
     }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -56,8 +56,8 @@ public interface GradleProject extends Directory {
     }
 
     private static Path createValidatedDirectory(Path parent, String name, String type) {
-        Preconditions.checkArgument(!name.contains(":"), "%s names must not %s contain colons", type, name);
-        Preconditions.checkArgument(!name.contains("/"), "%s names must not %s contain slashes", type, name);
+        Preconditions.checkArgument(!name.contains(":"), "%s names must not contain colons (project name was %s)", type, name);
+        Preconditions.checkArgument(!name.contains("/"), "%s names must not contain slashes (project name was %s)", type, name);
 
         Path dir = parent.resolve(name);
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -33,7 +33,7 @@ public interface GradleProject extends Directory {
     RootProject rootProject();
 
     default SubProject subproject(String name) {
-        Path subprojectDir = createChildProjectDir(path(), name);
+        Path subprojectDir = createChildProjectDir(name);
 
         String subprojectPath =
                 rootProject().path().relativize(subprojectDir).toString().replace('/', ':');

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -33,7 +33,16 @@ public interface GradleProject extends Directory {
     RootProject rootProject();
 
     default SubProject subproject(String name) {
-        Path subprojectDir = createValidatedDirectory(path(), name, "Subproject");
+        Preconditions.checkArgument(!name.contains(":"), "Subproject names must not %s contain colons", name);
+        Preconditions.checkArgument(!name.contains("/"), "Subproject names must not %s contain slashes", name);
+
+        Path subprojectDir = path().resolve(name);
+
+        try {
+            Files.createDirectories(subprojectDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
 
         String subprojectPath =
                 rootProject().path().relativize(subprojectDir).toString().replace('/', ':');
@@ -41,23 +50,6 @@ public interface GradleProject extends Directory {
         rootProject().settingsGradle().include(subprojectPath);
 
         return new SubProject(subprojectDir, rootProject());
-    }
-
-    private static Path createValidatedDirectory(Path parent, String name, String type) {
-        Preconditions.checkArgument(
-                !name.contains(":"), "%s names must not contain colons (project name was %s)", type, name);
-        Preconditions.checkArgument(
-                !name.contains("/"), "%s names must not contain slashes (project name was %s)", type, name);
-
-        Path dir = parent.resolve(name);
-
-        try {
-            Files.createDirectories(dir);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-
-        return dir;
     }
 
     default GradleFile buildGradle() {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -43,14 +43,6 @@ public interface GradleProject extends Directory {
         return new SubProject(subprojectDir, rootProject());
     }
 
-    default IncludedBuild includedBuild(String name) {
-        Path includedBuildDir = createValidatedDirectory(rootProject().path(), name, "Included build");
-
-        rootProject().settingsGradle().includeBuild(name);
-
-        return new IncludedBuild(name, includedBuildDir);
-    }
-
     private static Path createValidatedDirectory(Path parent, String name, String type) {
         Preconditions.checkArgument(
                 !name.contains(":"), "%s names must not contain colons (project name was %s)", type, name);

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -33,16 +33,7 @@ public interface GradleProject extends Directory {
     RootProject rootProject();
 
     default SubProject subproject(String name) {
-        Preconditions.checkArgument(!name.contains(":"), "Subproject names must not %s contain colons", name);
-        Preconditions.checkArgument(!name.contains("/"), "Subproject names must not %s contain slashes", name);
-
-        Path subprojectDir = path().resolve(name);
-
-        try {
-            Files.createDirectories(subprojectDir);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        Path subprojectDir = createChildProjectDir(path(), name);
 
         String subprojectPath =
                 rootProject().path().relativize(subprojectDir).toString().replace('/', ':');
@@ -50,6 +41,23 @@ public interface GradleProject extends Directory {
         rootProject().settingsGradle().include(subprojectPath);
 
         return new SubProject(subprojectDir, rootProject());
+    }
+
+    static Path createChildProjectDir(Path parentDir, String name) {
+        Preconditions.checkArgument(
+                !name.contains(":"), "Project names must not contain colons (project name was %s)", name);
+        Preconditions.checkArgument(
+                !name.contains("/"), "Project names must not contain slashes (project name was %s)", name);
+
+        Path childDir = parentDir.resolve(name);
+
+        try {
+            Files.createDirectories(childDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return childDir;
     }
 
     default GradleFile buildGradle() {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -46,13 +46,9 @@ public interface GradleProject extends Directory {
     default IncludedBuild includedBuild(String name) {
         Path includedBuildDir = createValidatedDirectory(rootProject().path(), name, "Included build");
 
-        RootProject includedBuildRoot = new RootProject(includedBuildDir);
-        includedBuildRoot.settingsGradle().rootProjectName(name);
-        includedBuildRoot.gradlePropertiesFile().setProperty("org.gradle.parallel", "true");
-
         rootProject().settingsGradle().includeBuild(name);
 
-        return new IncludedBuild(includedBuildDir, includedBuildRoot);
+        return new IncludedBuild(name, includedBuildDir);
     }
 
     private static Path createValidatedDirectory(Path parent, String name, String type) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -43,13 +43,13 @@ public interface GradleProject extends Directory {
         return new SubProject(subprojectDir, rootProject());
     }
 
-    static Path createChildProjectDir(Path parentDir, String name) {
+    default Path createChildProjectDir(String name) {
         Preconditions.checkArgument(
                 !name.contains(":"), "Project names must not contain colons (project name was %s)", name);
         Preconditions.checkArgument(
                 !name.contains("/"), "Project names must not contain slashes (project name was %s)", name);
 
-        Path childDir = parentDir.resolve(name);
+        Path childDir = path().resolve(name);
 
         try {
             Files.createDirectories(childDir);

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -56,8 +56,10 @@ public interface GradleProject extends Directory {
     }
 
     private static Path createValidatedDirectory(Path parent, String name, String type) {
-        Preconditions.checkArgument(!name.contains(":"), "%s names must not contain colons (project name was %s)", type, name);
-        Preconditions.checkArgument(!name.contains("/"), "%s names must not contain slashes (project name was %s)", type, name);
+        Preconditions.checkArgument(
+                !name.contains(":"), "%s names must not contain colons (project name was %s)", type, name);
+        Preconditions.checkArgument(
+                !name.contains("/"), "%s names must not contain slashes (project name was %s)", type, name);
 
         Path dir = parent.resolve(name);
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/GradleProject.java
@@ -33,16 +33,7 @@ public interface GradleProject extends Directory {
     RootProject rootProject();
 
     default SubProject subproject(String name) {
-        Preconditions.checkArgument(!name.contains(":"), "Subproject names must not %s contain colons", name);
-        Preconditions.checkArgument(!name.contains("/"), "Subproject names must not %s contain slashes", name);
-
-        Path subprojectDir = path().resolve(name);
-
-        try {
-            Files.createDirectories(subprojectDir);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        Path subprojectDir = createValidatedDirectory(path(), name, "Subproject");
 
         String subprojectPath =
                 rootProject().path().relativize(subprojectDir).toString().replace('/', ':');
@@ -50,6 +41,33 @@ public interface GradleProject extends Directory {
         rootProject().settingsGradle().include(subprojectPath);
 
         return new SubProject(subprojectDir, rootProject());
+    }
+
+    default IncludedBuild includedBuild(String name) {
+        Path includedBuildDir = createValidatedDirectory(rootProject().path(), name, "Included build");
+
+        RootProject includedBuildRoot = new RootProject(includedBuildDir);
+        includedBuildRoot.settingsGradle().rootProjectName(name);
+        includedBuildRoot.gradlePropertiesFile().setProperty("org.gradle.parallel", "true");
+
+        rootProject().settingsGradle().includeBuild(name);
+
+        return new IncludedBuild(includedBuildDir, includedBuildRoot);
+    }
+
+    private static Path createValidatedDirectory(Path parent, String name, String type) {
+        Preconditions.checkArgument(!name.contains(":"), "%s names must not %s contain colons", type, name);
+        Preconditions.checkArgument(!name.contains("/"), "%s names must not %s contain slashes", type, name);
+
+        Path dir = parent.resolve(name);
+
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return dir;
     }
 
     default GradleFile buildGradle() {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
@@ -23,14 +23,11 @@ import com.palantir.gradle.testing.files.properties.PropertiesFile;
 import java.nio.file.Path;
 
 /**
- * Represents an included build (composite build) in a Gradle project. When injected as a parameter in JUnit test
- * methods, the parameter name will be used as the build name exactly. For example, {@code IncludedBuild myLib}
- * creates an included build named "myLib" and registers it via {@code includeBuild 'myLib'} in the root project's
- * settings.gradle.
+ * When injected as a parameter in JUnit test methods, the parameter name will be used as the build name exactly.
+ * For example, {@code IncludedBuild myLib} creates an included build named "myLib".
  * <br>
- * An included build is a standalone Gradle build with its own {@code settings.gradle} and {@code build.gradle},
- * and can contain its own subprojects. The {@link #rootProject()} method returns a {@link RootProject} scoped to
- * this included build, so {@link #subproject(String)} registers subprojects in this build's settings.gradle.
+ * When injected, the included build will be registered via {@code includeBuild} in the
+ * root project's settings.gradle.
  */
 public record IncludedBuild(Path path, RootProject rootProject) implements GradleProject {
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
@@ -29,9 +29,27 @@ import java.nio.file.Path;
  * When injected, the included build will be registered via {@code includeBuild} in the
  * root project's settings.gradle.
  */
-public record IncludedBuild(Path path, RootProject rootProject) implements GradleProject {
+public final class IncludedBuild implements GradleProject {
+    private final Path path;
+    private final RootProject rootProject;
+
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
-    public IncludedBuild {}
+    public IncludedBuild(String name, Path path) {
+        this.path = path;
+        this.rootProject = new RootProject(path);
+        this.rootProject.settingsGradle().rootProjectName(name);
+        this.rootProject.gradlePropertiesFile().setProperty("org.gradle.parallel", "true");
+    }
+
+    @Override
+    public Path path() {
+        return path;
+    }
+
+    @Override
+    public RootProject rootProject() {
+        return rootProject;
+    }
 
     public SettingsGradleFile settingsGradle() {
         return rootProject.settingsGradle();

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
@@ -30,12 +30,10 @@ import java.nio.file.Path;
  * root project's settings.gradle.
  */
 public final class IncludedBuild implements GradleProject {
-    private final Path path;
     private final RootProject rootProject;
 
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
     public IncludedBuild(String name, Path path) {
-        this.path = path;
         this.rootProject = new RootProject(path);
         this.rootProject.settingsGradle().rootProjectName(name);
         this.rootProject.gradlePropertiesFile().setProperty("org.gradle.parallel", "true");
@@ -43,7 +41,7 @@ public final class IncludedBuild implements GradleProject {
 
     @Override
     public Path path() {
-        return path;
+        return rootProject.path();
     }
 
     @Override

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
@@ -27,18 +27,10 @@ import java.nio.file.Path;
  * When injected, the included build will be registered via {@code includeBuild} in the
  * root project's settings.gradle.
  */
-public final class IncludedBuild implements RootProject {
-    private final Path path;
-
+public record IncludedBuild(Path path) implements RootProject {
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
-    public IncludedBuild(String name, Path path) {
+    public IncludedBuild(Path path) {
         this.path = path;
-        settingsGradle().rootProjectName(name);
         gradlePropertiesFile().setProperty("org.gradle.parallel", "true");
-    }
-
-    @Override
-    public Path path() {
-        return path;
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/IncludedBuild.java
@@ -1,0 +1,46 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.testing.project;
+
+import com.google.errorprone.annotations.RestrictedApi;
+import com.palantir.gradle.testing.RestrictedCreation;
+import com.palantir.gradle.testing.files.gradle.SettingsGradleFile;
+import com.palantir.gradle.testing.files.properties.PropertiesFile;
+import java.nio.file.Path;
+
+/**
+ * Represents an included build (composite build) in a Gradle project. When injected as a parameter in JUnit test
+ * methods, the parameter name will be used as the build name exactly. For example, {@code IncludedBuild myLib}
+ * creates an included build named "myLib" and registers it via {@code includeBuild 'myLib'} in the root project's
+ * settings.gradle.
+ * <br>
+ * An included build is a standalone Gradle build with its own {@code settings.gradle} and {@code build.gradle},
+ * and can contain its own subprojects. The {@link #rootProject()} method returns a {@link RootProject} scoped to
+ * this included build, so {@link #subproject(String)} registers subprojects in this build's settings.gradle.
+ */
+public record IncludedBuild(Path path, RootProject rootProject) implements GradleProject {
+    @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
+    public IncludedBuild {}
+
+    public SettingsGradleFile settingsGradle() {
+        return rootProject.settingsGradle();
+    }
+
+    public PropertiesFile gradlePropertiesFile() {
+        return rootProject.gradlePropertiesFile();
+    }
+}

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
@@ -16,12 +16,8 @@
 
 package com.palantir.gradle.testing.project;
 
-import com.google.common.base.Preconditions;
 import com.palantir.gradle.testing.files.gradle.SettingsGradleFile;
 import com.palantir.gradle.testing.files.properties.PropertiesFile;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -43,18 +39,7 @@ public interface RootProject extends GradleProject {
     }
 
     default IncludedBuild includedBuild(String name) {
-        Preconditions.checkArgument(
-                !name.contains(":"), "Included build names must not contain colons (project name was %s)", name);
-        Preconditions.checkArgument(
-                !name.contains("/"), "Included build names must not contain slashes (project name was %s)", name);
-
-        Path includedBuildDir = path().resolve(name);
-
-        try {
-            Files.createDirectories(includedBuildDir);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        Path includedBuildDir = GradleProject.createChildProjectDir(path(), name);
 
         settingsGradle().includeBuild(name);
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
@@ -16,8 +16,13 @@
 
 package com.palantir.gradle.testing.project;
 
+import com.google.common.base.Preconditions;
 import com.palantir.gradle.testing.files.gradle.SettingsGradleFile;
 import com.palantir.gradle.testing.files.properties.PropertiesFile;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * A Gradle project that is the root of a build, having its own {@code settings.gradle} and
@@ -35,5 +40,24 @@ public interface RootProject extends GradleProject {
 
     default PropertiesFile gradlePropertiesFile() {
         return propertiesFile("gradle.properties");
+    }
+
+    default IncludedBuild includedBuild(String name) {
+        Preconditions.checkArgument(
+                !name.contains(":"), "Included build names must not contain colons (project name was %s)", name);
+        Preconditions.checkArgument(
+                !name.contains("/"), "Included build names must not contain slashes (project name was %s)", name);
+
+        Path includedBuildDir = path().resolve(name);
+
+        try {
+            Files.createDirectories(includedBuildDir);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        settingsGradle().includeBuild(name);
+
+        return new IncludedBuild(name, includedBuildDir);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
@@ -39,7 +39,7 @@ public interface RootProject extends GradleProject {
     }
 
     default IncludedBuild includedBuild(String name) {
-        Path includedBuildDir = GradleProject.createChildProjectDir(path(), name);
+        Path includedBuildDir = createChildProjectDir(name);
 
         settingsGradle().includeBuild(name);
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
@@ -16,30 +16,24 @@
 
 package com.palantir.gradle.testing.project;
 
-import com.google.errorprone.annotations.RestrictedApi;
-import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.files.gradle.SettingsGradleFile;
 import com.palantir.gradle.testing.files.properties.PropertiesFile;
-import java.nio.file.Path;
 
 /**
- * The root project will always be named "root" by default. To use a different project name, call
- * {@code rootProject.settingsGradle().rootProjectName("custom-name")}.
+ * A Gradle project that is the root of a build, having its own {@code settings.gradle} and
+ * {@code gradle.properties}. Both the top-level project and included builds are root projects.
  */
-public record RootProject(Path path) implements GradleProject {
-    @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
-    public RootProject {}
-
+public interface RootProject extends GradleProject {
     @Override
-    public RootProject rootProject() {
+    default RootProject rootProject() {
         return this;
     }
 
-    public SettingsGradleFile settingsGradle() {
-        return new SettingsGradleFile(path.resolve("settings.gradle"));
+    default SettingsGradleFile settingsGradle() {
+        return new SettingsGradleFile(path().resolve("settings.gradle"));
     }
 
-    public PropertiesFile gradlePropertiesFile() {
+    default PropertiesFile gradlePropertiesFile() {
         return propertiesFile("gradle.properties");
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/RootProject.java
@@ -58,6 +58,6 @@ public interface RootProject extends GradleProject {
 
         settingsGradle().includeBuild(name);
 
-        return new IncludedBuild(name, includedBuildDir);
+        return new IncludedBuild(includedBuildDir);
     }
 }

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/TopLevelRootProject.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/project/TopLevelRootProject.java
@@ -21,24 +21,11 @@ import com.palantir.gradle.testing.RestrictedCreation;
 import java.nio.file.Path;
 
 /**
- * When injected as a parameter in JUnit test methods, the parameter name will be used as the build name exactly.
- * For example, {@code IncludedBuild myLib} creates an included build named "myLib".
- * <br>
- * When injected, the included build will be registered via {@code includeBuild} in the
- * root project's settings.gradle.
+ * The top-level root project of a Gradle build. Will always be named "root" by default.
+ * To use a different project name, call
+ * {@code rootProject.settingsGradle().rootProjectName("custom-name")}.
  */
-public final class IncludedBuild implements RootProject {
-    private final Path path;
-
+public record TopLevelRootProject(Path path) implements RootProject {
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
-    public IncludedBuild(String name, Path path) {
-        this.path = path;
-        settingsGradle().rootProjectName(name);
-        gradlePropertiesFile().setProperty("org.gradle.parallel", "true");
-    }
-
-    @Override
-    public Path path() {
-        return path;
-    }
+    public TopLevelRootProject {}
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
@@ -156,8 +156,12 @@ class ProjectUsagesTest {
             println "hello from ${path}"
             """);
 
-        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: myLib");
-        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("hello from :sub-module");
+        gradle.withArgs()
+                .buildsSuccessfully()
+                .assertThat()
+                .output()
+                .contains("included build name: myLib")
+                .contains("hello from :sub-module");
     }
 
     @Test
@@ -169,8 +173,12 @@ class ProjectUsagesTest {
             println "included build name: ${name}"
             """);
 
-        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included settings evaluated");
-        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: myLib");
+        gradle.withArgs()
+                .buildsSuccessfully()
+                .assertThat()
+                .output()
+                .contains("included settings evaluated")
+                .contains("included build name: myLib");
     }
 
     @Test
@@ -195,8 +203,12 @@ class ProjectUsagesTest {
             println "outer build name: ${name}"
             """);
 
-        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("outer build name: outerLib");
-        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("inner build name: inner");
+        gradle.withArgs()
+                .buildsSuccessfully()
+                .assertThat()
+                .output()
+                .contains("outer build name: outerLib")
+                .contains("inner build name: inner");
     }
 
     @Test

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
@@ -17,14 +17,12 @@
 package com.palantir.gradle.testing.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.IncludedBuild;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.gradle.testing.project.SubProject;
-import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -231,9 +229,11 @@ class ProjectUsagesTest {
         rootProject.subproject("shared");
         rootProject.includedBuild("shared");
 
-        assertThatThrownBy(() -> gradle.withArgs().buildsSuccessfully())
-                .isInstanceOf(UnexpectedBuildFailure.class)
-                .hasMessageContaining("has name 'shared' which is the same as a project of the main build.");
+        gradle.withArgs()
+                .buildsWithFailure()
+                .assertThat()
+                .output()
+                .contains("has name 'shared' which is the same as a project of the main build.");
     }
 
     @Nested

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
@@ -229,7 +229,7 @@ class ProjectUsagesTest {
         rootProject.subproject("shared");
         rootProject.includedBuild("shared");
 
-        gradle.withArgs("help")
+        gradle.withArgs()
                 .buildsWithFailure()
                 .assertThat()
                 .output()

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
+import com.palantir.gradle.testing.project.IncludedBuild;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.gradle.testing.project.SubProject;
 import org.junit.jupiter.api.BeforeEach;
@@ -120,6 +121,95 @@ class ProjectUsagesTest {
             """);
 
         gradle.withArgs().buildsSuccessfully().assertThat().output().contains("hello from :subproject");
+    }
+
+    @Test
+    void included_build_uses_exact_parameter_name(GradleInvoker gradle, IncludedBuild myLib) {
+        myLib.buildGradle().append("""
+            println "included build name: ${name}"
+            """);
+
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: myLib");
+    }
+
+    @Test
+    void included_build_manually(GradleInvoker gradle, RootProject rootProject) {
+        IncludedBuild includedBuild = rootProject.includedBuild("my-included");
+
+        includedBuild.buildGradle().append("""
+            println "included build name: ${name}"
+            """);
+
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: my-included");
+    }
+
+    @Test
+    void included_build_with_subproject(GradleInvoker gradle, IncludedBuild myLib) {
+        myLib.buildGradle().append("""
+            println "included build name: ${name}"
+            """);
+
+        SubProject sub = myLib.subproject("sub-module");
+        sub.buildGradle().append("""
+            println "hello from ${path}"
+            """);
+
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: myLib");
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("hello from :sub-module");
+    }
+
+    @Test
+    void included_build_settings_gradle(GradleInvoker gradle, IncludedBuild myLib) {
+        myLib.settingsGradle().append("""
+            println "included settings evaluated"
+            """);
+        myLib.buildGradle().append("""
+            println "included build name: ${name}"
+            """);
+
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included settings evaluated");
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: myLib");
+    }
+
+    @Test
+    void included_build_gradle_properties(GradleInvoker gradle, IncludedBuild myLib) {
+        myLib.gradlePropertiesFile().setProperty("myProp", "fromIncludedBuild");
+        myLib.buildGradle().append("""
+            println "myProp: ${findProperty('myProp')}"
+            """);
+
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("myProp: fromIncludedBuild");
+    }
+
+    @Test
+    void nested_included_build(GradleInvoker gradle, IncludedBuild outerLib) {
+        IncludedBuild innerLib = outerLib.includedBuild("inner");
+
+        innerLib.buildGradle().append("""
+            println "inner build name: ${name}"
+            """);
+
+        outerLib.buildGradle().append("""
+            println "outer build name: ${name}"
+            """);
+
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("outer build name: outerLib");
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("inner build name: inner");
+    }
+
+    @Test
+    void can_request_the_same_included_build_multiple_times(GradleInvoker gradle, RootProject rootProject) {
+        IncludedBuild first = rootProject.includedBuild("shared");
+        IncludedBuild second = rootProject.includedBuild("shared");
+
+        assertThat(second.path()).isEqualTo(first.path());
+        rootProject.settingsGradle().assertThat().content().containsOnlyOnce("includeBuild 'shared'");
+
+        first.buildGradle().append("""
+            println "included build name: ${name}"
+            """);
+
+        gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: shared");
     }
 
     @Nested

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
@@ -17,6 +17,7 @@
 package com.palantir.gradle.testing.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
@@ -210,6 +211,24 @@ class ProjectUsagesTest {
             """);
 
         gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: shared");
+    }
+
+    @Test
+    void subproject_then_included_build_with_same_name_throws(RootProject rootProject) {
+        rootProject.subproject("shared");
+
+        assertThatThrownBy(() -> rootProject.includedBuild("shared"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("already registered as a subproject");
+    }
+
+    @Test
+    void included_build_then_subproject_with_same_name_throws(RootProject rootProject) {
+        rootProject.includedBuild("shared");
+
+        assertThatThrownBy(() -> rootProject.subproject("shared"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("already registered as an included build");
     }
 
     @Nested

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
@@ -17,7 +17,6 @@
 package com.palantir.gradle.testing.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
@@ -211,24 +210,6 @@ class ProjectUsagesTest {
             """);
 
         gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: shared");
-    }
-
-    @Test
-    void subproject_then_included_build_with_same_name_throws(RootProject rootProject) {
-        rootProject.subproject("shared");
-
-        assertThatThrownBy(() -> rootProject.includedBuild("shared"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("already registered as a subproject");
-    }
-
-    @Test
-    void included_build_then_subproject_with_same_name_throws(RootProject rootProject) {
-        rootProject.includedBuild("shared");
-
-        assertThatThrownBy(() -> rootProject.subproject("shared"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("already registered as an included build");
     }
 
     @Nested

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
@@ -17,12 +17,14 @@
 package com.palantir.gradle.testing.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.junit.GradlePluginTests;
 import com.palantir.gradle.testing.project.IncludedBuild;
 import com.palantir.gradle.testing.project.RootProject;
 import com.palantir.gradle.testing.project.SubProject;
+import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -210,6 +212,16 @@ class ProjectUsagesTest {
             """);
 
         gradle.withArgs().buildsSuccessfully().assertThat().output().contains("included build name: shared");
+    }
+
+    @Test
+    void subproject_then_included_build_with_same_name_throws(GradleInvoker gradle, RootProject rootProject) {
+        rootProject.subproject("shared");
+        rootProject.includedBuild("shared");
+
+        assertThatThrownBy(() -> gradle.withArgs().buildsSuccessfully())
+                .isInstanceOf(UnexpectedBuildFailure.class)
+                .hasMessageContaining("has name 'shared' which is the same as a project of the main build.");
     }
 
     @Nested

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/integration/ProjectUsagesTest.java
@@ -229,7 +229,7 @@ class ProjectUsagesTest {
         rootProject.subproject("shared");
         rootProject.includedBuild("shared");
 
-        gradle.withArgs()
+        gradle.withArgs("help")
                 .buildsWithFailure()
                 .assertThat()
                 .output()

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
@@ -190,6 +190,28 @@ class ConfigurationCacheTests {
         result.assertThat().output().contains("has name 'shared' which is the same as a project of the main build.");
     }
 
+    @Test
+    void fails_when_configuration_cache_cannot_be_reused(GradleInvoker invoker, RootProject rootProject) {
+        rootProject.buildGradle().append("""
+                tasks.register("some") {
+                    def propsFile = project.layout.projectDirectory.file('gradle.properties').asFile
+                    doLast {
+                        def props = new Properties()
+                        propsFile.withInputStream { props.load(it) }
+                        props.setProperty('version', 'two')
+                        propsFile.withOutputStream { props.store(it, null) }
+                        throw new RuntimeException("Version changed from one to two")
+                    }
+                }
+            """);
+
+        rootProject.gradlePropertiesFile().setProperty("version", "one");
+        assertThatThrownBy(() -> invoker.withArgs("some").buildsWithFailure())
+                .isInstanceOf(UnexpectedConfigurationCacheFailure.class)
+                .hasMessageContaining(
+                        "Configuration cache reuse failure: The second run failed to reuse the cached configuration.");
+    }
+
     static void setUpConfigurationCacheTask(GradleProject project) {
         project.buildGradle().append("""
             tasks.register("checkConfigurationCache") {

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/junit/ConfigurationCacheTests.java
@@ -181,6 +181,15 @@ class ConfigurationCacheTests {
         result.assertThat().output().contains("org.gradle.api.GradleScriptException:");
     }
 
+    @Test
+    void included_build_name_collision_does_not_run_dry_run(GradleInvoker invoker, RootProject rootProject) {
+        rootProject.subproject("shared");
+        rootProject.includedBuild("shared");
+
+        InvocationResult result = invoker.withArgs().buildsWithFailure();
+        result.assertThat().output().contains("has name 'shared' which is the same as a project of the main build.");
+    }
+
     static void setUpConfigurationCacheTask(GradleProject project) {
         project.buildGradle().append("""
             tasks.register("checkConfigurationCache") {

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/project/GradleProjectTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/project/GradleProjectTest.java
@@ -30,7 +30,7 @@ class GradleProjectTest {
 
     @BeforeEach
     void beforeEach(@TempDir Path tempDir) {
-        gradleProject = new RootProject(tempDir);
+        gradleProject = new TopLevelRootProject(tempDir);
     }
 
     @Nested


### PR DESCRIPTION
## Before this PR
With us starting to support included builds, and some tests already testing included builds, it felt that the framework was missing native support for example see https://github.com/palantir/gradle-consistent-versions/pull/1508#discussion_r2917321124

Users testing plugins that interact with `includeBuild` directives had to manually create directories, write `settings.gradle` files, and wire up `includeBuild` directives — verbose and error-prone.

## After this PR

Adds `IncludedBuild` as a new injectable parameter type. It works the same way as `SubProject` — the parameter name becomes the build name, and everything is wired up automatically.

**Parameter injection:**
```java
@Test
void composite_build(GradleInvoker gradle, IncludedBuild myLib) {
    myLib.buildGradle().plugins().add("java-library");
    gradle.withArgs("tasks").buildsSuccessfully();
}
```

**Programmatic creation:**
```java
IncludedBuild lib = rootProject.includedBuild("my-lib");
```

## Possible downsides?

## Test plan

- `included_build_uses_exact_parameter_name` — parameter name becomes build name
- `included_build_manually` — programmatic creation via `rootProject.includedBuild()`
- `included_build_with_subproject` — subprojects within an included build
- `included_build_settings_gradle` — custom settings.gradle content is evaluated
- `included_build_gradle_properties` — gradle.properties are readable from the included build
- `nested_included_build` — included build within an included build
- `can_request_the_same_included_build_multiple_times` — idempotency