### PR TITLE
Add explicit callout to use `uri("%s")` instead of raw `file:///` URLs

### DIFF
--- a/docs/junit-migration-excavator-instructions.md
+++ b/docs/junit-migration-excavator-instructions.md
@@ -286,6 +286,8 @@ rootProject.buildGradle().append("""
     """, repo.path());
 ```
 
+**Use `uri("%s")` when referencing paths in build.gradle**: Do not use raw `file:///...` URLs — Gradle 9.0 removed legacy URL decoding, so paths with spaces or special characters will error. Use `uri("%s")` instead, which handles encoding correctly.
+
 **Skip unnecessary setup**: Don't call `settingsGradle().rootProjectName()` unless you need a custom name.
 
 **Use exact assertions for lock files**: Prefer `isEqualTo()` with text blocks over `contains()` for lock file content - makes expected output obvious.


### PR DESCRIPTION
## Before this PR

Gradle 9.0 removed legacy invalid URL decoding, so test runs with paths containing spaces would fail when using raw `file:///...` URLs in build.gradle text blocks.

## After this PR

Adds an explicit callout in the migration instructions telling LLMs not to use raw `file:///...` URLs and to use `uri("%s")` instead, which handles path encoding correctly.

## Possible downsides?
