### PR TITLE
Replace `ProjectLayout.getSettingsDirectory()` with Gradle 8.8 compatible API when running gradle less than 8.10

### DIFF
--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -116,6 +116,14 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
         Provider<String> testDependenciesFileAbsolutePath = project.provider(() ->
                 testDependencyVersions.get().getOutputFile().get().getAsFile().getAbsolutePath());
 
+        RegularFile testVersionsConfigPath;
+        if (GradleVersion.current().compareTo(GradleVersion.version("8.10")) >= 0) {
+            testVersionsConfigPath = getProjectLayout().getSettingsDirectory().file("gradle/gradle-test-versions.yml");
+        } else {
+            testVersionsConfigPath =
+                    project.getRootProject().getLayout().getProjectDirectory().file("gradle/gradle-test-versions.yml");
+        }
+
         project.getTasks().withType(Test.class).configureEach(test -> {
             test.dependsOn(testDependencyVersions);
 
@@ -133,8 +141,8 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
                             testDependenciesFileAbsolutePath.get());
 
                     // add system property for what versions of gradle should be used in tests
-                    Set<String> versionsFromConfig =
-                            readGradleTestingVersionsConfigFile().getOrElse(Set.of());
+                    Set<String> versionsFromConfig = readGradleTestingVersionsConfigFile(testVersionsConfigPath)
+                            .getOrElse(Set.of());
                     Set<String> versionsFromExtension =
                             testUtilsExt.getGradleVersions().get();
                     Set<String> gradleTestVersions = ImmutableSet.<String>builder()
@@ -286,10 +294,7 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
         });
     }
 
-    private Provider<Set<String>> readGradleTestingVersionsConfigFile() {
-        RegularFile testVersionsConfigPath =
-                getProjectLayout().getSettingsDirectory().file("gradle/gradle-test-versions.yml");
-
+    private Provider<Set<String>> readGradleTestingVersionsConfigFile(RegularFile testVersionsConfigPath) {
         Provider<GradleTestVersionsConfig> config = getProviderFactory()
                 .fileContents(testVersionsConfigPath)
                 .getAsText()


### PR DESCRIPTION
##  Before this PR
`ProjectLayout.getSettingsDirectory()` was introduced in Gradle 8.10. Consumers still on Gradle 8.8 get a `NoSuchMethodError` when applying this plugin.                                                                                                                                                                  

## After this PR                                                                                                                                                                                                                                                                                                         
Uses `project.getRootProject().getLayout().getProjectDirectory()` to resolve the `gradle/gradle-test-versions.yml` path when running on gradle version less than 8.10

## Possible downsides?
This assumes the settings directory is the same as the root project directory, which is true for standard single-root-project builds. Although I think this is fine for all of our current usages