### PR TITLE
Add `gradleDistributionBaseUrl` extension property

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -769,8 +769,7 @@ void plugin_reads_environment_variable(GradleInvoker gradle, RootProject project
 
 ### Custom Gradle Distribution URL
 
-By default, tests download Gradle distributions from `services.gradle.org`. To use a custom distribution server
-(e.g. an internal Artifactory mirror), set `gradleDistributionBaseUrl` on the extension:
+By default, tests download Gradle distributions from `services.gradle.org`. To use a custom distribution server, set `gradleDistributionBaseUrl` on the extension:
 
 ```groovy
 gradleTestUtils {

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -767,6 +767,19 @@ void plugin_reads_environment_variable(GradleInvoker gradle, RootProject project
 }
 ```
 
+### Custom Gradle Distribution URL
+
+By default, tests download Gradle distributions from `services.gradle.org`. To use a custom distribution server
+(e.g. an internal Artifactory mirror), set `gradleDistributionBaseUrl` on the extension:
+
+```groovy
+gradleTestUtils {
+    gradleDistributionBaseUrl = 'https://my-artifactory.example.com/gradle-distributions'
+}
+```
+
+When set, tests will download Gradle from `{baseUrl}/gradle-{version}-bin.zip` instead of the default server.
+
 ## Assertions
 
 ### Fluent Assertion API

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -773,7 +773,7 @@ By default, tests download Gradle distributions from `services.gradle.org`. To u
 
 ```groovy
 gradleTestUtils {
-    gradleDistributionBaseUrl = 'https://my-artifactory.example.com/gradle-distributions'
+    gradleDistributionBaseUrl = 'https://example.com/gradle-distributions'
 }
 ```
 

--- a/gradle-plugin-testing-junit/build.gradle
+++ b/gradle-plugin-testing-junit/build.gradle
@@ -37,3 +37,8 @@ dependencies {
 gradleTestUtils {
     configurationCacheEnabled = true
 }
+
+// TODO(gradle-plugin-testing): remove once buildscript classpath is updated to a version that sets this property
+tasks.named('test', Test) {
+    systemProperty 'com.palantir.gradle.testing.gradle_distribution_base_url', 'https://services.gradle.org/distributions'
+}

--- a/gradle-plugin-testing-junit/build.gradle
+++ b/gradle-plugin-testing-junit/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     implementation 'commons-io:commons-io'
     implementation 'com.google.guava:guava'
+    implementation project(':plugin-testing-core')
 
     compileOnly 'org.immutables:value'
     annotationProcessor 'org.immutables:value'

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.testing.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.RestrictedApi;
+import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import com.palantir.gradle.testing.RestrictedCreation;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -61,8 +62,8 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
 
     private URI gradleDistributionUri() {
         String baseUrl = Optional.ofNullable(
-                        System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url"))
-                .orElse("https://services.gradle.org/distributions");
+                        System.getProperty(GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY))
+                .orElse(GradleDistributionBaseUrl.DEFAULT_BASE_URL);
         return URI.create(baseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip");
     }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -27,7 +27,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import org.gradle.testkit.runner.GradleRunner;
 
 record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) implements GradleInvoker {
@@ -61,9 +60,7 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
     }
 
     private URI gradleDistributionUri() {
-        String baseUrl = Optional.ofNullable(
-                        System.getProperty(GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY))
-                .orElse(GradleDistributionBaseUrl.DEFAULT_BASE_URL);
+        String baseUrl = System.getProperty(GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY);
         return URI.create(baseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip");
     }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import org.gradle.testkit.runner.GradleRunner;
 
 record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) implements GradleInvoker {
@@ -60,9 +59,7 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
     }
 
     private URI gradleDistributionUri() {
-        String baseUrl = Optional.ofNullable(
-                        System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url"))
-                .orElse("https://services.gradle.org/distributions");
+        String baseUrl = System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url");
         return URI.create(baseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip");
     }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -22,6 +22,7 @@ import com.palantir.gradle.testing.RestrictedCreation;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
@@ -41,16 +42,24 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
                 .withDebug(GradleInvoker.shouldRunInTestkitDebugMode())
                 .forwardStdOutput(captureWriter)
                 .forwardStdError(captureWriter)
-                .withGradleVersion(gradleVersion.version())
-                .withPluginClasspath()
-                .withArguments(ImmutableList.<String>builder()
-                        .addAll(options.args())
-                        .add("--stacktrace")
-                        .add("-P__TESTING=true")
-                        .addAll(options.testingEnvironmentVariables().entrySet().stream()
-                                .map(e -> String.format("-P__TESTING_%s=%s", e.getKey(), e.getValue()))
-                                .toList())
-                        .build());
+                .withPluginClasspath();
+
+        String distributionBaseUrl = System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url");
+        if (distributionBaseUrl != null) {
+            runner.withGradleDistribution(
+                    URI.create(distributionBaseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip"));
+        } else {
+            runner.withGradleVersion(gradleVersion.version());
+        }
+
+        runner.withArguments(ImmutableList.<String>builder()
+                .addAll(options.args())
+                .add("--stacktrace")
+                .add("-P__TESTING=true")
+                .addAll(options.testingEnvironmentVariables().entrySet().stream()
+                        .map(e -> String.format("-P__TESTING_%s=%s", e.getKey(), e.getValue()))
+                        .toList())
+                .build());
         options.customGradleUserHome().ifPresent(gradleUserHome -> runner.withTestKitDir(gradleUserHome.toFile()));
 
         String title = buildTitle(options.args());

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -18,7 +18,6 @@ package com.palantir.gradle.testing.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.RestrictedApi;
-import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import com.palantir.gradle.testing.RestrictedCreation;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
@@ -29,7 +28,8 @@ import java.nio.file.Path;
 import java.util.List;
 import org.gradle.testkit.runner.GradleRunner;
 
-record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) implements GradleInvoker {
+record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion, String gradleDistributionBaseUrl)
+        implements GradleInvoker {
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
     public DefaultGradleInvoker {}
 
@@ -60,8 +60,7 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
     }
 
     private URI gradleDistributionUri() {
-        String baseUrl = System.getProperty(GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY);
-        return URI.create(baseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip");
+        return URI.create(gradleDistributionBaseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip");
     }
 
     private String buildTitle(List<String> args) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import org.gradle.testkit.runner.GradleRunner;
 
 record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) implements GradleInvoker {
@@ -59,7 +60,9 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
     }
 
     private URI gradleDistributionUri() {
-        String baseUrl = System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url");
+        String baseUrl = Optional.ofNullable(
+                        System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url"))
+                .orElse("https://services.gradle.org/distributions");
         return URI.create(baseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip");
     }
 

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/DefaultGradleInvoker.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import org.gradle.testkit.runner.GradleRunner;
 
 record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) implements GradleInvoker {
@@ -42,28 +43,27 @@ record DefaultGradleInvoker(Path rootProjectDir, GradleVersion gradleVersion) im
                 .withDebug(GradleInvoker.shouldRunInTestkitDebugMode())
                 .forwardStdOutput(captureWriter)
                 .forwardStdError(captureWriter)
-                .withPluginClasspath();
-
-        String distributionBaseUrl = System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url");
-        if (distributionBaseUrl != null) {
-            runner.withGradleDistribution(
-                    URI.create(distributionBaseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip"));
-        } else {
-            runner.withGradleVersion(gradleVersion.version());
-        }
-
-        runner.withArguments(ImmutableList.<String>builder()
-                .addAll(options.args())
-                .add("--stacktrace")
-                .add("-P__TESTING=true")
-                .addAll(options.testingEnvironmentVariables().entrySet().stream()
-                        .map(e -> String.format("-P__TESTING_%s=%s", e.getKey(), e.getValue()))
-                        .toList())
-                .build());
+                .withPluginClasspath()
+                .withGradleDistribution(gradleDistributionUri())
+                .withArguments(ImmutableList.<String>builder()
+                        .addAll(options.args())
+                        .add("--stacktrace")
+                        .add("-P__TESTING=true")
+                        .addAll(options.testingEnvironmentVariables().entrySet().stream()
+                                .map(e -> String.format("-P__TESTING_%s=%s", e.getKey(), e.getValue()))
+                                .toList())
+                        .build());
         options.customGradleUserHome().ifPresent(gradleUserHome -> runner.withTestKitDir(gradleUserHome.toFile()));
 
         String title = buildTitle(options.args());
         return new DefaultGradleInvocation(runner, title, capturedOutput);
+    }
+
+    private URI gradleDistributionUri() {
+        String baseUrl = Optional.ofNullable(
+                        System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url"))
+                .orElse("https://services.gradle.org/distributions");
+        return URI.create(baseUrl + "/gradle-" + gradleVersion.version() + "-bin.zip");
     }
 
     private String buildTitle(List<String> args) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/execution/GradleInvoker.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.errorprone.annotations.RestrictedApi;
+import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.junit.DecoratorContext;
 import com.palantir.gradle.testing.junit.GradleInvokerDecorator;
@@ -54,11 +55,20 @@ public interface GradleInvoker {
     GradleInvocation with(Options options);
 
     static GradleInvoker create(Path path, GradleVersion gradleVersion, ExtensionContext extensionContext) {
-        GradleInvoker baseInvoker = getInternalDefaultInvoker(path, gradleVersion);
+        String baseUrl = readGradleDistributionBaseUrl(extensionContext);
+        GradleInvoker baseInvoker = getInternalDefaultInvoker(path, gradleVersion, baseUrl);
         RootProject rootProject = new TopLevelRootProject(path);
         DecoratorContext decoratorContext = new DecoratorContext(rootProject, gradleVersion, extensionContext);
         Set<Annotation> annotations = collectAnnotationsFromContext(extensionContext);
         return decorateInvokerWithAnnotations(decoratorContext, baseInvoker, annotations);
+    }
+
+    static String readGradleDistributionBaseUrl(ExtensionContext extensionContext) {
+        return extensionContext
+                .getConfigurationParameter(GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY)
+                .orElseThrow(() -> new RuntimeException(
+                        "Could not determine the Gradle distribution base URL. Have you applied the latest"
+                                + " `com.palantir.gradle-plugin-testing` plugin to this project?"));
     }
 
     private static Set<Annotation> collectAnnotationsFromContext(ExtensionContext context) {
@@ -206,8 +216,8 @@ public interface GradleInvoker {
             explanation =
                     "For internal use only. Always prefer GradleInvoker#create for the creation of the GradleInvokers.",
             allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
-    static GradleInvoker getInternalDefaultInvoker(Path path, GradleVersion gradleVersion) {
-        return new DefaultGradleInvoker(path, gradleVersion);
+    static GradleInvoker getInternalDefaultInvoker(Path path, GradleVersion gradleVersion, String baseUrl) {
+        return new DefaultGradleInvoker(path, gradleVersion, baseUrl);
     }
 
     static boolean shouldRunInTestkitDebugMode() {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/ConfigurationCacheDecorator.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/ConfigurationCacheDecorator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.testing.junit;
 
+import com.palantir.gradle.plugintesting.ConfigurationCacheHelper;
 import com.palantir.gradle.testing.execution.ConfigurationCacheInvoker;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import java.lang.annotation.Annotation;
@@ -36,7 +37,7 @@ public final class ConfigurationCacheDecorator implements GradleInvokerDecorator
         }
 
         boolean configurationCacheEnabled = context.extensionContext()
-                .getConfigurationParameter("com.palantir.gradle.testing.configuration_cache_enabled")
+                .getConfigurationParameter(ConfigurationCacheHelper.CONFIG_CACHE_SYSTEM_PROPERTY)
                 .map(Boolean::parseBoolean)
                 .orElseThrow(() -> new RuntimeException(
                         "Could not configure whether to run the tests with configuration-cache. Have you"

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/MavenRepoStore.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/MavenRepoStore.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.testing.junit;
 
+import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.GradleVersion;
 import com.palantir.gradle.testing.maven.MavenRepo;
 import java.io.IOException;
@@ -46,7 +47,7 @@ final class MavenRepoStore {
 
         clearDirectory(repositoryDirectory);
 
-        return new MavenRepo(repositoryDirectory, gradleVersion);
+        return new MavenRepo(repositoryDirectory, gradleVersion, GradleInvoker.readGradleDistributionBaseUrl(context));
     }
 
     private static void clearDirectory(Path mavenRepoDirectory) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/MavenRepoStore.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/MavenRepoStore.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.testing.junit;
 import com.palantir.gradle.testing.execution.GradleInvoker;
 import com.palantir.gradle.testing.execution.GradleVersion;
 import com.palantir.gradle.testing.maven.MavenRepo;
+import com.palantir.gradle.testing.project.TopLevelRootProject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -47,7 +48,12 @@ final class MavenRepoStore {
 
         clearDirectory(repositoryDirectory);
 
-        return new MavenRepo(repositoryDirectory, gradleVersion, GradleInvoker.readGradleDistributionBaseUrl(context));
+        Path repoDirPath = repositoryDirectory.resolve("localMavenRepositoryPublisherProject");
+        Path mavenRepoUrl = repositoryDirectory.resolve("localMavenRepository").toAbsolutePath();
+        String gradleDistributionBaseUrl = GradleInvoker.readGradleDistributionBaseUrl(context);
+        GradleInvoker invoker =
+                GradleInvoker.getInternalDefaultInvoker(repoDirPath, gradleVersion, gradleDistributionBaseUrl);
+        return new MavenRepo(mavenRepoUrl, new TopLevelRootProject(repoDirPath), invoker);
     }
 
     private static void clearDirectory(Path mavenRepoDirectory) {

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/MavenRepoStore.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/junit/MavenRepoStore.java
@@ -49,7 +49,7 @@ final class MavenRepoStore {
         clearDirectory(repositoryDirectory);
 
         Path repoDirPath = repositoryDirectory.resolve("localMavenRepositoryPublisherProject");
-        Path mavenRepoUrl = repositoryDirectory.resolve("localMavenRepository").toAbsolutePath();
+        Path mavenRepoUrl = repositoryDirectory.resolve("localMavenRepository");
         String gradleDistributionBaseUrl = GradleInvoker.readGradleDistributionBaseUrl(context);
         GradleInvoker invoker =
                 GradleInvoker.getInternalDefaultInvoker(repoDirPath, gradleVersion, gradleDistributionBaseUrl);

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepo.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepo.java
@@ -56,13 +56,13 @@ public final class MavenRepo {
     private final MavenRepoPublisher publisher;
 
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
-    public MavenRepo(Path repoDir, GradleVersion gradleVersion) {
+    public MavenRepo(Path repoDir, GradleVersion gradleVersion, String gradleDistributionBaseUrl) {
         this.mavenRepoUrl = repoDir.resolve("localMavenRepository").toAbsolutePath();
         Path repoDirPath = repoDir.resolve("localMavenRepositoryPublisherProject");
         this.publisher = new MavenRepoPublisher(
                 mavenRepoUrl,
                 new TopLevelRootProject(repoDirPath),
-                GradleInvoker.getInternalDefaultInvoker(repoDirPath, gradleVersion));
+                GradleInvoker.getInternalDefaultInvoker(repoDirPath, gradleVersion, gradleDistributionBaseUrl));
     }
 
     /**

--- a/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepo.java
+++ b/gradle-plugin-testing-junit/src/main/java/com/palantir/gradle/testing/maven/MavenRepo.java
@@ -19,8 +19,7 @@ package com.palantir.gradle.testing.maven;
 import com.google.errorprone.annotations.RestrictedApi;
 import com.palantir.gradle.testing.RestrictedCreation;
 import com.palantir.gradle.testing.execution.GradleInvoker;
-import com.palantir.gradle.testing.execution.GradleVersion;
-import com.palantir.gradle.testing.project.TopLevelRootProject;
+import com.palantir.gradle.testing.project.RootProject;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -56,13 +55,9 @@ public final class MavenRepo {
     private final MavenRepoPublisher publisher;
 
     @RestrictedApi(explanation = RestrictedCreation.EXPLANATION, allowedOnPath = RestrictedCreation.ALLOWED_ON_PATH)
-    public MavenRepo(Path repoDir, GradleVersion gradleVersion, String gradleDistributionBaseUrl) {
-        this.mavenRepoUrl = repoDir.resolve("localMavenRepository").toAbsolutePath();
-        Path repoDirPath = repoDir.resolve("localMavenRepositoryPublisherProject");
-        this.publisher = new MavenRepoPublisher(
-                mavenRepoUrl,
-                new TopLevelRootProject(repoDirPath),
-                GradleInvoker.getInternalDefaultInvoker(repoDirPath, gradleVersion, gradleDistributionBaseUrl));
+    public MavenRepo(Path mavenRepoUrl, RootProject rootProject, GradleInvoker invoker) {
+        this.mavenRepoUrl = mavenRepoUrl;
+        this.publisher = new MavenRepoPublisher(mavenRepoUrl, rootProject, invoker);
     }
 
     /**

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/AdditionallyRunWithGradleTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/AdditionallyRunWithGradleTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.example.AdditionallyRunWithGradleFixtureTest;
 import com.palantir.example.MethodLevelAdditionallyRunWithGradleFixtureTest;
+import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import java.util.List;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,9 @@ final class AdditionallyRunWithGradleTest {
                 // Base version configured via parameter
                 .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5")
                 .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
 
         List<Event> finished = executionResults.testEvents().finished().stream().toList();
@@ -58,6 +62,9 @@ final class AdditionallyRunWithGradleTest {
                 // 8.0 is both in config and in @AdditionallyRunWithGradle
                 .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "8.0")
                 .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
 
         List<Event> finished = executionResults.testEvents().finished().stream().toList();
@@ -77,6 +84,9 @@ final class AdditionallyRunWithGradleTest {
                 // Base version configured via parameter
                 .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5")
                 .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
 
         List<Event> finished = executionResults.testEvents().finished().stream().toList();

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/ConfigurationCacheParameterTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/ConfigurationCacheParameterTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.palantir.example.ConfigurationCacheFixtureTest;
 import com.palantir.example.DisabledConfigurationCacheFixtureTest;
 import com.palantir.example.DisabledConfigurationCacheFixtureTestBefore;
+import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -42,6 +43,9 @@ public class ConfigurationCacheParameterTest {
                 .configurationParameter(
                         "com.palantir.gradle.testing.configuration_cache_enabled",
                         String.valueOf(isConfigurationCacheEnabled))
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
 
         List<Event> finished = executionResults.testEvents().finished().stream().toList();
@@ -67,6 +71,9 @@ public class ConfigurationCacheParameterTest {
                 // we require a value for this parameter to be set. Setting it to `invalid` to make sure the value will
                 // always be overridden to false due to the `@DisabledConfigurationCache` annotation.
                 .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "invalid")
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
 
         List<Event> finished = executionResults.testEvents().finished().stream().toList();

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/GradleVersionsFromJunitParameterTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/GradleVersionsFromJunitParameterTest.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.testing.ete;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.example.GradleVersionsFromJunitParameterFixtureTest;
+import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
@@ -33,6 +34,9 @@ final class GradleVersionsFromJunitParameterTest {
                 .selectors(DiscoverySelectors.selectClass(GradleVersionsFromJunitParameterFixtureTest.class))
                 .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.14.3")
                 .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
 
         List<Event> finished = executionResults.testEvents().finished().stream().toList();

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/IncompatibleDecoratorsTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/IncompatibleDecoratorsTest.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.testing.ete;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.example.IncompatibleDecoratorsFixtureTest;
+import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestExecutionResult;
@@ -36,6 +37,9 @@ final class IncompatibleDecoratorsTest {
                 .selectors(DiscoverySelectors.selectClass(IncompatibleDecoratorsFixtureTest.class))
                 .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "8.14.3")
                 .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
 
         List<Event> finished = executionResults.testEvents().finished().stream().toList();

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/ParameterizedByGradleVersionTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/ParameterizedByGradleVersionTest.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.testing.ete;
 import static org.junit.platform.testkit.engine.EventConditions.reportEntry;
 
 import com.palantir.example.ParameterizedByGradleVersionFixtureTest;
+import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
@@ -130,6 +131,9 @@ final class ParameterizedByGradleVersionTest {
                 .selectors(DiscoverySelectors.selectClass(fixtureClass))
                 .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", gradleVersion)
                 .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "false")
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
     }
 }

--- a/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/ProjectDirsAreMadeCorrectlyInBuildDirTest.java
+++ b/gradle-plugin-testing-junit/src/test/java/com/palantir/gradle/testing/ete/ProjectDirsAreMadeCorrectlyInBuildDirTest.java
@@ -19,6 +19,7 @@ package com.palantir.gradle.testing.ete;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.palantir.example.ProjectDirsAreMadeCorrectlyInBuildDirFixtureTest;
+import com.palantir.gradle.plugintesting.GradleDistributionBaseUrl;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,9 @@ final class ProjectDirsAreMadeCorrectlyInBuildDirTest {
                 .selectors(DiscoverySelectors.selectClass(ProjectDirsAreMadeCorrectlyInBuildDirFixtureTest.class))
                 .configurationParameter("com.palantir.gradle.testing.gradle_versions_to_test", "7.6.5,8.14.3")
                 .configurationParameter("com.palantir.gradle.testing.configuration_cache_enabled", "true")
+                .configurationParameter(
+                        GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                        GradleDistributionBaseUrl.DEFAULT_BASE_URL)
                 .execute();
 
         executionResults.testEvents().finished().assertThatEvents().allSatisfy(event -> {

--- a/gradle-plugin-testing/build.gradle
+++ b/gradle-plugin-testing/build.gradle
@@ -46,6 +46,8 @@ gradlePlugin {
 
 tasks.named('test', Test) {
     systemProperty 'projectVersion', project.version
+    // TODO(gradle-plugin-testing): remove once buildscript classpath is updated to a version that sets this property
+    systemProperty 'com.palantir.gradle.testing.gradle_distribution_base_url', 'https://services.gradle.org/distributions'
 
     // Added as a jar the so in nebula-tests needs to exist in maven local
     dependsOn ':discover-tests-cli:publishToMavenLocal'

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingExtension.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingExtension.java
@@ -50,6 +50,6 @@ public abstract class PluginTestingExtension {
     public PluginTestingExtension() {
         getIgnoreGradleDeprecations().convention(true);
         getConfigurationCacheEnabled().convention(false);
-        getGradleDistributionBaseUrl().convention("https://services.gradle.org/distributions");
+        getGradleDistributionBaseUrl().convention(GradleDistributionBaseUrl.DEFAULT_BASE_URL);
     }
 }

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingExtension.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingExtension.java
@@ -41,6 +41,12 @@ public abstract class PluginTestingExtension {
      */
     public abstract Property<Boolean> getConfigurationCacheEnabled();
 
+    /**
+     * Base URL for downloading Gradle distributions. When set, tests will download Gradle from
+     * {@code {baseUrl}/gradle-{version}-bin.zip} instead of the default Gradle distribution server.
+     */
+    public abstract Property<String> getGradleDistributionBaseUrl();
+
     public PluginTestingExtension() {
         getIgnoreGradleDeprecations().convention(true);
         getConfigurationCacheEnabled().convention(false);

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingExtension.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingExtension.java
@@ -42,13 +42,14 @@ public abstract class PluginTestingExtension {
     public abstract Property<Boolean> getConfigurationCacheEnabled();
 
     /**
-     * Base URL for downloading Gradle distributions. When set, tests will download Gradle from
-     * {@code {baseUrl}/gradle-{version}-bin.zip} instead of the default Gradle distribution server.
+     * Base URL for downloading Gradle distributions. Tests will download Gradle from
+     * {@code {baseUrl}/gradle-{version}-bin.zip}.
      */
     public abstract Property<String> getGradleDistributionBaseUrl();
 
     public PluginTestingExtension() {
         getIgnoreGradleDeprecations().convention(true);
         getConfigurationCacheEnabled().convention(false);
+        getGradleDistributionBaseUrl().convention("https://services.gradle.org/distributions");
     }
 }

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -170,6 +170,13 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
                             ConfigurationCacheHelper.CONFIG_CACHE_SYSTEM_PROPERTY,
                             testUtilsExt.getConfigurationCacheEnabled().get());
 
+                    // add system property for custom gradle distribution base URL
+                    if (testUtilsExt.getGradleDistributionBaseUrl().isPresent()) {
+                        test.systemProperty(
+                                GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                                testUtilsExt.getGradleDistributionBaseUrl().get());
+                    }
+
                     // add system property to ignore gradle deprecations so that nebula tests don't fail
                     if (testUtilsExt.getIgnoreGradleDeprecations().get()) {
                         // from

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -170,12 +170,9 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
                             ConfigurationCacheHelper.CONFIG_CACHE_SYSTEM_PROPERTY,
                             testUtilsExt.getConfigurationCacheEnabled().get());
 
-                    // add system property for custom gradle distribution base URL
-                    if (testUtilsExt.getGradleDistributionBaseUrl().isPresent()) {
-                        test.systemProperty(
-                                GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
-                                testUtilsExt.getGradleDistributionBaseUrl().get());
-                    }
+                    test.systemProperty(
+                            GradleDistributionBaseUrl.GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY,
+                            testUtilsExt.getGradleDistributionBaseUrl().get());
 
                     // add system property to ignore gradle deprecations so that nebula tests don't fail
                     if (testUtilsExt.getIgnoreGradleDeprecations().get()) {

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -171,6 +171,35 @@ class PluginTestingJunitPluginTest {
     }
 
     @Test
+    void gradle_distribution_base_url_is_passed_as_system_property(
+            GradleInvoker gradleInvoker, RootProject rootProject) {
+
+        rootProject.buildGradle().append("""
+            gradleTestUtils {
+                gradleDistributionBaseUrl = 'https://example.com/gradle-distributions'
+            }
+            """);
+
+        rootProject.testSourceSet().java().writeClass("""
+            package test;
+
+            import static org.assertj.core.api.Assertions.assertThat;
+
+            import org.junit.jupiter.api.Test;
+
+            class TestClass {
+                @Test
+                void testMethod() {
+                    assertThat(System.getProperty("com.palantir.gradle.testing.gradle_distribution_base_url"))
+                            .isEqualTo("https://example.com/gradle-distributions");
+                }
+            }
+            """);
+
+        gradleInvoker.withArgs("test").buildsSuccessfully();
+    }
+
+    @Test
     void errorprones_are_injected_automatically(GradleInvoker gradle, RootProject rootProject) {
         rootProject.buildGradle().plugins().add("net.ltgt.errorprone");
 

--- a/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/ConfigurationCacheHelper.java
+++ b/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/ConfigurationCacheHelper.java
@@ -17,5 +17,5 @@
 package com.palantir.gradle.plugintesting;
 
 public record ConfigurationCacheHelper() {
-    static final String CONFIG_CACHE_SYSTEM_PROPERTY = "com.palantir.gradle.testing.configuration_cache_enabled";
+    public static final String CONFIG_CACHE_SYSTEM_PROPERTY = "com.palantir.gradle.testing.configuration_cache_enabled";
 }

--- a/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/GradleDistributionBaseUrl.java
+++ b/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/GradleDistributionBaseUrl.java
@@ -19,4 +19,5 @@ package com.palantir.gradle.plugintesting;
 public record GradleDistributionBaseUrl() {
     public static final String GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY =
             "com.palantir.gradle.testing.gradle_distribution_base_url";
+    public static final String DEFAULT_BASE_URL = "https://services.gradle.org/distributions";
 }

--- a/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/GradleDistributionBaseUrl.java
+++ b/plugin-testing-core/src/main/java/com/palantir/gradle/plugintesting/GradleDistributionBaseUrl.java
@@ -1,0 +1,22 @@
+/*
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.plugintesting;
+
+public record GradleDistributionBaseUrl() {
+    public static final String GRADLE_DISTRIBUTION_BASE_URL_SYSTEM_PROPERTY =
+            "com.palantir.gradle.testing.gradle_distribution_base_url";
+}


### PR DESCRIPTION
## Before this PR

Tests always download Gradle distributions from `services.gradle.org`. There was no way to configure an alternative distribution server (e.g. a local mirror or cache).

## After this PR

Adds a `gradleDistributionBaseUrl` property to the `gradleTestUtils` extension. When set, tests download Gradle from `{baseUrl}/gradle-{version}-bin.zip` instead of the default server.

```groovy
gradleTestUtils {
    gradleDistributionBaseUrl = 'https://my-mirror.example.com/gradle-distributions'
}
```

The value flows through as a system property (`com.palantir.gradle.testing.gradle_distribution_base_url`) to the test JVM, where `DefaultGradleInvoker` uses `GradleRunner.withGradleDistribution(URI)` instead of `withGradleVersion(String)`. When unset, behavior is unchanged.

## Possible downsides?

## Testing

- New integration test in `PluginTestingJunitPluginTest` verifies the system property is correctly propagated from the extension to the inner test JVM