### PR TITLE
tidy up "Add gradleDistributionBaseUrl extension property" now we are on that version

### DIFF
--- a/gradle-plugin-testing-junit/build.gradle
+++ b/gradle-plugin-testing-junit/build.gradle
@@ -38,7 +38,3 @@ gradleTestUtils {
     configurationCacheEnabled = true
 }
 
-// TODO(gradle-plugin-testing): remove once buildscript classpath is updated to a version that sets this property
-tasks.named('test', Test) {
-    systemProperty 'com.palantir.gradle.testing.gradle_distribution_base_url', 'https://services.gradle.org/distributions'
-}

--- a/gradle-plugin-testing/build.gradle
+++ b/gradle-plugin-testing/build.gradle
@@ -46,8 +46,6 @@ gradlePlugin {
 
 tasks.named('test', Test) {
     systemProperty 'projectVersion', project.version
-    // TODO(gradle-plugin-testing): remove once buildscript classpath is updated to a version that sets this property
-    systemProperty 'com.palantir.gradle.testing.gradle_distribution_base_url', 'https://services.gradle.org/distributions'
 
     // Added as a jar the so in nebula-tests needs to exist in maven local
     dependsOn ':discover-tests-cli:publishToMavenLocal'


### PR DESCRIPTION
## Before this PR
https://github.com/palantir/gradle-plugin-testing/pull/444 required some manual workaround until it used the latest version of itself [see here](https://github.com/palantir/gradle-plugin-testing/pull/444/changes#diff-36783d669b50c2e89eb6f52fd8354063b2bb0db9878546e86d5bf9ccd8b318abR42-R44)
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Now we use version 0.68.0 so we can remove those workarounds
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

