### PR TITLE
Isolate GCV types behind helper class so plugin loads without GCV on the classpath

### DIFF
--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/GradleConsistentVersionsInterop.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/GradleConsistentVersionsInterop.java
@@ -1,0 +1,34 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.plugintesting;
+
+import com.palantir.gradle.versions.VersionsLockExtension;
+import org.gradle.api.Project;
+
+/**
+ * Isolates GCV types so {@link PluginTestingPlugin} can be decorated without GCV on the classpath. Only call from
+ * inside a {@code withPlugin("com.palantir.consistent-versions", ...)} callback.
+ */
+final class GradleConsistentVersionsInterop {
+
+    static void registerTestScope(Project project, String resolvableConfigurationName) {
+        project.getExtensions()
+                .getByType(VersionsLockExtension.class)
+                .test(scope -> scope.from(resolvableConfigurationName));
+    }
+
+    private GradleConsistentVersionsInterop() {}
+}

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/GradleConsistentVersionsInterop.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/GradleConsistentVersionsInterop.java
@@ -19,7 +19,7 @@ import com.palantir.gradle.versions.VersionsLockExtension;
 import org.gradle.api.Project;
 
 /**
- * Isolates GCV types so {@link PluginTestingPlugin} can be decorated without GCV on the classpath. Only call from
+ * Isolates GCV type references so {@link PluginTestingPlugin} loads without GCV on the classpath. Only call from
  * inside a {@code withPlugin("com.palantir.consistent-versions", ...)} callback.
  */
 final class GradleConsistentVersionsInterop {

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -24,7 +24,6 @@ import com.palantir.baseline.tasks.CheckUnusedDependenciesParentTask;
 import com.palantir.gradle.plugintesting.TestDependencyVersionsTask.TestDependency;
 import com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorProneExtension;
 import com.palantir.gradle.suppressibleerrorprone.SuppressibleErrorPronePlugin;
-import com.palantir.gradle.versions.VersionsLockExtension;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -292,9 +291,7 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
         });
 
         project.getRootProject().getPluginManager().withPlugin("com.palantir.consistent-versions", _plugin -> {
-            project.getExtensions()
-                    .getByType(VersionsLockExtension.class)
-                    .test(scope -> scope.from(gradlePluginForTestingResolvable.getName()));
+            GradleConsistentVersionsInterop.registerTestScope(project, gradlePluginForTestingResolvable.getName());
         });
     }
 


### PR DESCRIPTION
## Before this PR                                                                                                                                                                                                                                                                                                     

`PluginTestingPlugin` imported `VersionsLockExtension` directly and referenced it inside a `withPlugin("com.palantir.consistent-versions", ...)` callback. Even though that callback only fires when GCV is applied, the type reference sits on `PluginTestingPlugin` itself,                  

```
║ > Failed to apply plugin class 'com.palantir.gradle.plugintesting.PluginTestingPlugin'.                                                                                                             
║    > Could not create plugin of type 'PluginTestingPlugin'.                                                                                                                                         
║       > Could not generate a decorated class for type PluginTestingPlugin.                                                                                                                          
║          > com/palantir/gradle/versions/VersionsLockExtension$ScopeConfigurer   
```                                                                                            

## After this PR                                                                                                                                                                                                                                                                                                      

The GCV call is moved into a new package-private `GradleConsistentVersionsInterop` helper. `PluginTestingPlugin` no longer imports any GCV types                                                                                                                                                                                                                    
