### PR TITLE
Add `discoverGradlePluginTestsAnnotatedTests` task

### DIFF
--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/DiscoverTestClassesTask.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/DiscoverTestClassesTask.java
@@ -87,7 +87,7 @@ public abstract class DiscoverTestClassesTask extends JavaExec {
                         getProjectLayout().getBuildDirectory(),
                         getTestClassType(),
                         (buildDirectory, testType) ->
-                                buildDirectory.dir(String.format("tests-discovery/%s", testType)));
+                                buildDirectory.dir(String.format("tests-discovery/%s/%s", getName(), testType)));
 
         getDiscoveredTestsFile().convention(outputRootDirectory.map(outputRoot -> outputRoot.file("test-classes")));
         getOutputFile().convention(outputRootDirectory.map(outputRoot -> outputRoot.file("test-classes-paths")));

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -202,6 +202,23 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
                                             "com.palantir.gradle.testing.junit.DisabledConfigurationCache"));
                         });
 
+        project.getTasks().register("discoverGradlePluginTestsAnnotatedTests", DiscoverTestClassesTask.class, task -> {
+            task.getTestClassType().set("java");
+            // Override the default output paths so this task does not collide with
+            // discoverGradlePluginTestsWithDisabledConfigurationCache (both use testClassType=java).
+            task.getDiscoveredTestsFile()
+                    .set(project.getLayout()
+                            .getBuildDirectory()
+                            .file("tests-discovery/gradle-plugin-tests-annotated/test-classes"));
+            task.getOutputFile()
+                    .set(project.getLayout()
+                            .getBuildDirectory()
+                            .file("tests-discovery/gradle-plugin-tests-annotated/test-classes-paths"));
+            task.getExtraArguments()
+                    .addAll(List.of(
+                            "withAnnotations", "--include", "com.palantir.gradle.testing.junit.GradlePluginTests"));
+        });
+
         project.getTasks().register("discoverNebulaTestClassesToMigrate", DiscoverTestClassesTask.class, task -> {
             task.getTestClassType().set("groovy");
             task.getExtraArguments()

--- a/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
+++ b/gradle-plugin-testing/src/main/java/com/palantir/gradle/plugintesting/PluginTestingPlugin.java
@@ -204,16 +204,6 @@ public abstract class PluginTestingPlugin implements Plugin<Project> {
 
         project.getTasks().register("discoverGradlePluginTestsAnnotatedTests", DiscoverTestClassesTask.class, task -> {
             task.getTestClassType().set("java");
-            // Override the default output paths so this task does not collide with
-            // discoverGradlePluginTestsWithDisabledConfigurationCache (both use testClassType=java).
-            task.getDiscoveredTestsFile()
-                    .set(project.getLayout()
-                            .getBuildDirectory()
-                            .file("tests-discovery/gradle-plugin-tests-annotated/test-classes"));
-            task.getOutputFile()
-                    .set(project.getLayout()
-                            .getBuildDirectory()
-                            .file("tests-discovery/gradle-plugin-tests-annotated/test-classes-paths"));
             task.getExtraArguments()
                     .addAll(List.of(
                             "withAnnotations", "--include", "com.palantir.gradle.testing.junit.GradlePluginTests"));

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -301,11 +301,11 @@ class PluginTestingJunitPluginTest {
 
         gradle.withArgs("discoverGradlePluginTestsWithDisabledConfigurationCache")
                 .buildsSuccessfully();
-        assertThat(readTestClassesPaths(rootProject, "java"))
+        assertThat(readTestClassesPaths(rootProject, "discoverGradlePluginTestsWithDisabledConfigurationCache", "java"))
                 .containsExactlyInAnyOrder("src/test/java/test/NoConfigCacheGradlePluginTestClass.java");
 
         gradle.withArgs("discoverGradlePluginTestsAnnotatedTests").buildsSuccessfully();
-        assertThat(readGradlePluginTestsAnnotatedPaths(rootProject))
+        assertThat(readTestClassesPaths(rootProject, "discoverGradlePluginTestsAnnotatedTests", "java"))
                 .containsExactlyInAnyOrder(
                         "src/test/java/test/GradlePluginTestClass.java",
                         "src/test/java/test/NoConfigCacheGradlePluginTestClass.java");
@@ -356,7 +356,7 @@ class PluginTestingJunitPluginTest {
         });
 
         gradle.withArgs("discoverNebulaTestClassesToMigrate").buildsSuccessfully();
-        assertThat(readTestClassesPaths(rootProject, "groovy"))
+        assertThat(readTestClassesPaths(rootProject, "discoverNebulaTestClassesToMigrate", "groovy"))
                 .containsExactlyInAnyOrder(
                         "src/test/groovy/test/NebulaIntegrationTest.groovy",
                         "src/test/groovy/test/SubClassesNebulaIntegrationTest.groovy",
@@ -421,24 +421,17 @@ class PluginTestingJunitPluginTest {
             """);
 
         gradle.withArgs("discoverNebulaTestClassesToMigrate").buildsSuccessfully();
-        assertThat(readTestClassesPaths(rootProject, "groovy"))
+        assertThat(readTestClassesPaths(rootProject, "discoverNebulaTestClassesToMigrate", "groovy"))
                 .containsExactlyInAnyOrder(
                         "src/test/groovy/test/TestSourceSetSpec.groovy",
                         "src/integrationTest/groovy/test/IntegrationSourceSetSpec.groovy");
     }
 
-    private static List<String> readTestClassesPaths(RootProject rootProject, String language) throws IOException {
+    private static List<String> readTestClassesPaths(RootProject rootProject, String taskName, String language)
+            throws IOException {
         return Files.readAllLines(rootProject
                 .buildDir()
-                .directory(String.format("tests-discovery/%s", language))
-                .file("test-classes-paths")
-                .path());
-    }
-
-    private static List<String> readGradlePluginTestsAnnotatedPaths(RootProject rootProject) throws IOException {
-        return Files.readAllLines(rootProject
-                .buildDir()
-                .directory("tests-discovery/gradle-plugin-tests-annotated")
+                .directory(String.format("tests-discovery/%s/%s", taskName, language))
                 .file("test-classes-paths")
                 .path());
     }

--- a/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
+++ b/gradle-plugin-testing/src/test/java/com/palantir/gradle/plugintesting/PluginTestingJunitPluginTest.java
@@ -303,6 +303,12 @@ class PluginTestingJunitPluginTest {
                 .buildsSuccessfully();
         assertThat(readTestClassesPaths(rootProject, "java"))
                 .containsExactlyInAnyOrder("src/test/java/test/NoConfigCacheGradlePluginTestClass.java");
+
+        gradle.withArgs("discoverGradlePluginTestsAnnotatedTests").buildsSuccessfully();
+        assertThat(readGradlePluginTestsAnnotatedPaths(rootProject))
+                .containsExactlyInAnyOrder(
+                        "src/test/java/test/GradlePluginTestClass.java",
+                        "src/test/java/test/NoConfigCacheGradlePluginTestClass.java");
     }
 
     @Test
@@ -425,6 +431,14 @@ class PluginTestingJunitPluginTest {
         return Files.readAllLines(rootProject
                 .buildDir()
                 .directory(String.format("tests-discovery/%s", language))
+                .file("test-classes-paths")
+                .path());
+    }
+
+    private static List<String> readGradlePluginTestsAnnotatedPaths(RootProject rootProject) throws IOException {
+        return Files.readAllLines(rootProject
+                .buildDir()
+                .directory("tests-discovery/gradle-plugin-tests-annotated")
                 .file("test-classes-paths")
                 .path());
     }


### PR DESCRIPTION
## Before this PR
There is no built-in way to ask "does this project have any `@GradlePluginTests`-annotated test classes?". The existing `discoverGradlePluginTestsWithDisabledConfigurationCache` task only finds the strict subset that also has `@DisabledConfigurationCache`.

## After this PR
A new `discoverGradlePluginTestsAnnotatedTests` task is registered on every project that applies `com.palantir.gradle-plugin-testing`. It finds any class annotated with `@GradlePluginTests` regardless of whether `@DisabledConfigurationCache` is also present.

==COMMIT_MSG==
Register discoverGradlePluginTestsAnnotatedTests task to discover any test class annotated with @GradlePluginTests
==COMMIT_MSG==

## Possible downsides?